### PR TITLE
Change how basline is called after changing filename

### DIFF
--- a/mappers/HighEfficiency.rb
+++ b/mappers/HighEfficiency.rb
@@ -32,7 +32,7 @@ require 'urbanopt/scenario'
 require 'openstudio/common_measures'
 require 'openstudio/model_articulation'
 
-require_relative 'BaselineMapper'
+require_relative 'Baseline'
 
 require 'json'
 


### PR DESCRIPTION
This is needed after changing the name of `BaselineMapper.rb` to `Baseline.rb`