### PR TITLE
Disabling walk in refrigeration  

### DIFF
--- a/mappers/base_workflow.osw
+++ b/mappers/base_workflow.osw
@@ -9,7 +9,7 @@
     {
       "measure_dir_name": "set_run_period",
       "arguments": {
-        "timesteps_per_hour": 1,
+        "timesteps_per_hour": 4,
         "begin_date": "2019-06-01",
         "end_date": "2019-08-01"
       }
@@ -49,16 +49,19 @@
       "name": "create_typical_building_from_model 1",
       "measure_dir_name": "create_typical_building_from_model",
       "arguments": {
-        "add_hvac": false
+        "add_hvac": false,
+        "add_refrigeration": false
       } 
     },{
       "measure_dir_name": "blended_space_type_from_model",
       "arguments": {
+        "__SKIP__": false,
         "blend_method": "Building Story"
       }
     },{
       "measure_dir_name": "urban_geometry_creation",
       "arguments": {
+        "__SKIP__": false,
         "geojson_file": "exportGeo.json",
         "feature_id": "5",
         "surrounding_buildings": "None"
@@ -67,6 +70,7 @@
       "name": "create_typical_building_from_model 2",
       "measure_dir_name": "create_typical_building_from_model",
       "arguments": {
+        "__SKIP__": false,
         "template": "90.1-2004",
         "add_constructions": false,
         "add_space_type_loads": false,
@@ -74,6 +78,7 @@
         "add_exterior_lights": false,
         "add_exhaust": false,
         "add_swh": false,
+        "add_refrigeration": false,
         "remove_objects": false,
         "system_type": "Inferred",
         "add_hvac": true,


### PR DESCRIPTION
Refrigeration is new to create_tyipcal from earlier versions so we didn't hit this before. Unlike SWH which doesn't have to be tied to a space and can survey geometry being replaced, that isn't the case for walk in refrigeration which requires a zone. My recommendation for now is not to include refrigeration when using urban_geometry.

I made an addition of __SKIP__ argument into blend, urban_geometry, and second create_typical instance to both test that refrigeration works when using _create_bar and also to provide users a path to easily switch between the two workflows with the same template OSW. I have left the __SKIP__ value to false for now, but if you turn them to true, and then set add refrigeration and hvac to true on the first instance of create_typical everything runs fine.

One last change was setting timestep to 4 per hour instead of 1. I hit warnings in EnergyPlus when it was set to 1 time step an hour.