### PR TITLE
updating one geojson and three primary mappers to support hours of operation inputs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,13 +49,13 @@ else
   gem 'urbanopt-geojson', '~> 0.6.1'
 end
 
-if allow_local && File.exist?('../urbanopt-reopt-gem')
-  gem 'urbanopt-reopt', path: '../urbanopt-reopt-gem'
-elsif allow_local
-  gem 'urbanopt-reopt', github: 'URBANopt/urbanopt-reopt-gem', branch: 'comm_sol_enhance'
-else
-  gem 'urbanopt-reopt', '0.6.0'
-end
+#if allow_local && File.exist?('../urbanopt-reopt-gem')
+#  gem 'urbanopt-reopt', path: '../urbanopt-reopt-gem'
+#elsif allow_local
+  gem 'urbanopt-reopt', github: 'URBANopt/urbanopt-reopt-gem', branch: 'develop'
+#else
+#  gem 'urbanopt-reopt', '0.6.0'
+#end
 
 if allow_local && File.exist?('../openstudio-load-flexibility-measures-gem')
   gem 'openstudio-load-flexibility-measures', path: '../openstudio-load-flexibility-measures-gem'

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ end
 if allow_local && File.exist?('../urbanopt-reopt-gem')
   gem 'urbanopt-reopt', path: '../urbanopt-reopt-gem'
 elsif allow_local
-  gem 'urbanopt-reopt', github: 'URBANopt/urbanopt-reopt-gem', branch: 'develop'
+  gem 'urbanopt-reopt', github: 'URBANopt/urbanopt-reopt-gem', branch: 'comm_sol_enhance'
 else
   gem 'urbanopt-reopt', '0.6.0'
 end

--- a/example_project/example_project_combined.json
+++ b/example_project/example_project_combined.json
@@ -147,7 +147,11 @@
         "building_type": "Food service",
         "floor_area": 125631,
         "footprint_area": 41877,
-        "number_of_stories": 3
+        "number_of_stories": 3,
+        "weekday_start_time": "11:00",
+        "weekday_duration": "11:30",
+        "weekend_start_time": "11:00",
+        "weekend_duration": "11:30"
       },
       "geometry": {
         "type": "Polygon",
@@ -186,7 +190,11 @@
         "building_type": "Food service",
         "floor_area": 31623,
         "footprint_area": 10541,
-        "number_of_stories": 3
+        "number_of_stories": 3,
+        "weekday_start_time": "06:00",
+        "weekday_duration": "07:00",
+        "weekend_start_time": "08:00",
+        "weekend_duration": "05:00"
       },
       "geometry": {
         "type": "Polygon",
@@ -225,7 +233,9 @@
         "building_type": "Food service",
         "floor_area": 8804,
         "footprint_area": 8804,
-        "number_of_stories": 1
+        "number_of_stories": 1,
+        "weekday_start_time": "06:00",
+        "weekday_duration": "16:00"
       },
       "geometry": {
         "type": "Polygon",

--- a/example_project/mappers/Baseline.rb
+++ b/example_project/mappers/Baseline.rb
@@ -933,12 +933,17 @@ module URBANopt
                 end
               end
 
+              # geojson schema doesn't have modify_wkdy_op_hrs and modify_wknd_op_hrs checking for both start and duration to set to true in osw
+              weekday_flag = 0 # set modify arg to true of this gets to 2
+              weekend_flag = 0 # set modify arg to true of this gets to 2
+
               # set weekday start time
               begin
                 weekday_start_time = feature.weekday_start_time
                 if !feature.weekday_start_time.empty?
                   new_weekday_start_time = time_mapping(weekday_start_time)
                   OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wkdy_op_hrs_start_time', new_weekday_start_time, 'create_typical_building_from_model 1')
+                  weekday_flag += 1
                 end
               rescue
               end
@@ -949,6 +954,15 @@ module URBANopt
                 if !feature.weekday_duration.empty?
                   new_weekday_duration = time_mapping(weekday_duration)
                   OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wkdy_op_hrs_duration', new_weekday_duration, 'create_typical_building_from_model 1')
+                  weekday_flag += 1
+                end
+              rescue
+              end
+
+              # set weekday modify 
+              begin
+                if weekday_flag == 2
+                  OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model 1')
                 end
               rescue
               end
@@ -959,6 +973,7 @@ module URBANopt
                 if !feature.weekend_start_time.empty?
                   new_weekend_start_time = time_mapping(weekend_start_time)
                   OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wknd_op_hrs_start_time', new_weekend_start_time, 'create_typical_building_from_model 1')
+                  weekend_flag += 1
                 end
               rescue
               end
@@ -969,10 +984,19 @@ module URBANopt
                 if !feature.weekend_duration.empty?
                   new_weekend_duration = time_mapping(weekend_duration)
                   OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wknd_op_hrs_duration', new_weekend_duration, 'create_typical_building_from_model 1')
+                  weekend_flag += 1
                 end
               rescue
               end
 
+              # set weekday modify 
+              begin
+                if weekend_flag == 2
+                  OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model 1')
+                end
+              rescue
+              end
+              
               # template
               begin
                 new_template = nil

--- a/example_project/mappers/Baseline.rb
+++ b/example_project/mappers/Baseline.rb
@@ -962,7 +962,7 @@ module URBANopt
               # set weekday modify 
               begin
                 if weekday_flag == 2
-                  OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model 1')
+                  OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wkdy_op_hrs', true, 'create_typical_building_from_model 1')
                 end
               rescue
               end

--- a/example_project/mappers/CreateBar.rb
+++ b/example_project/mappers/CreateBar.rb
@@ -517,7 +517,7 @@ module URBANopt
             # set weekday modify 
             begin
               if weekend_flag == 2
-                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model')
+                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wkdy_op_hrs', true, 'create_typical_building_from_model')
               end
             rescue StandardError
             end

--- a/example_project/mappers/CreateBar.rb
+++ b/example_project/mappers/CreateBar.rb
@@ -458,12 +458,17 @@ module URBANopt
               end
             end
 
+            # geojson schema doesn't have modify_wkdy_op_hrs and modify_wknd_op_hrs checking for both start and duration to set to true in osw
+            weekday_flag = 0 # set modify arg to true of this gets to 2
+            weekend_flag = 0 # set modify arg to true of this gets to 2
+
             # set weekday start time
             begin
               weekday_start_time = feature.weekday_start_time
               if !feature.weekday_start_time.empty?
                 new_weekday_start_time = time_mapping(weekday_start_time)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wkdy_op_hrs_start_time', new_weekday_start_time, 'create_typical_building_from_model')
+                weekday_flag += 1
               end
             rescue StandardError
             end
@@ -474,6 +479,15 @@ module URBANopt
               if !feature.weekday_duration.empty?
                 new_weekday_duration = time_mapping(weekday_duration)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wkdy_op_hrs_duration', new_weekday_duration, 'create_typical_building_from_model')
+                weekday_flag += 1
+              end
+            rescue StandardError
+            end
+
+            # set weekday modify 
+            begin
+              if weekday_flag == 2
+                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model')
               end
             rescue StandardError
             end
@@ -484,6 +498,7 @@ module URBANopt
               if !feature.weekend_start_time.empty?
                 new_weekend_start_time = time_mapping(weekend_start_time)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wknd_op_hrs_start_time', new_weekend_start_time, 'create_typical_building_from_model')
+                weekend_flag += 1
               end
             rescue StandardError
             end
@@ -494,6 +509,15 @@ module URBANopt
               if !feature.weekend_duration.empty?
                 new_weekend_duration = time_mapping(weekend_duration)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wknd_op_hrs_duration', new_weekend_duration, 'create_typical_building_from_model')
+                weekend_flag += 1
+              end
+            rescue StandardError
+            end
+
+            # set weekday modify 
+            begin
+              if weekend_flag == 2
+                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model')
               end
             rescue StandardError
             end

--- a/example_project/mappers/Floorspace.rb
+++ b/example_project/mappers/Floorspace.rb
@@ -544,12 +544,17 @@ module URBANopt
               end
             end
 
+            # geojson schema doesn't have modify_wkdy_op_hrs and modify_wknd_op_hrs checking for both start and duration to set to true in osw
+            weekday_flag = 0 # set modify arg to true of this gets to 2
+            weekend_flag = 0 # set modify arg to true of this gets to 2
+
             # set weekday start time
             begin
               weekday_start_time = feature.weekday_start_time
               if !feature.weekday_start_time.empty?
                 new_weekday_start_time = time_mapping(weekday_start_time)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wkdy_op_hrs_start_time', new_weekday_start_time, 'create_typical_building_from_model 1')
+                weekday_flag += 1
               end
             rescue StandardError
             end
@@ -560,6 +565,15 @@ module URBANopt
               if !feature.weekday_duration.empty?
                 new_weekday_duration = time_mapping(weekday_duration)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wkdy_op_hrs_duration', new_weekday_duration, 'create_typical_building_from_model 1')
+                weekday_flag += 1
+              end
+            rescue StandardError
+            end
+
+            # set weekday modify 
+            begin
+              if weekday_flag == 2
+                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model 1')
               end
             rescue StandardError
             end
@@ -570,6 +584,7 @@ module URBANopt
               if !feature.weekend_start_time.empty?
                 new_weekend_start_time = time_mapping(weekend_start_time)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wknd_op_hrs_start_time', new_weekend_start_time, 'create_typical_building_from_model 1')
+                weekend_flag += 1
               end
             rescue StandardError
             end
@@ -580,6 +595,15 @@ module URBANopt
               if !feature.weekend_duration.empty?
                 new_weekend_duration = time_mapping(weekend_duration)
                 OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'wknd_op_hrs_duration', new_weekend_duration, 'create_typical_building_from_model 1')
+                weekend_flag += 1
+              end
+            rescue StandardError
+            end
+
+            # set weekday modify 
+            begin
+              if weekend_flag == 2
+                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model 1')
               end
             rescue StandardError
             end

--- a/example_project/mappers/Floorspace.rb
+++ b/example_project/mappers/Floorspace.rb
@@ -573,7 +573,7 @@ module URBANopt
             # set weekday modify 
             begin
               if weekday_flag == 2
-                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wknd_op_hrs', true, 'create_typical_building_from_model 1')
+                OpenStudio::Extension.set_measure_argument(osw, 'create_typical_building_from_model', 'modify_wkdy_op_hrs', true, 'create_typical_building_from_model 1')
               end
             rescue StandardError
             end


### PR DESCRIPTION
I only applied this one one of the geojson files. I picked building type that there were a lot of and did a variety of hours of operation combination, leaving at least one restaurant with default hours of operation.