### PR TITLE
Support for custom HPXMLs

### DIFF
--- a/example_project/example_project_combined.json
+++ b/example_project/example_project_combined.json
@@ -778,7 +778,8 @@
         "system_type": "Residential - furnace and room air conditioner",
         "heating_system_fuel_type": "fuel oil",
         "number_of_residential_units": 4,
-        "template": "Residential IECC 2015 - Customizable Template Sep 2020"
+        "template": "Residential IECC 2015 - Customizable Template Sep 2020",
+        "hpxml_directory": "17"
       },
       "geometry": {
         "type": "Polygon",

--- a/example_project/mappers/Baseline.rb
+++ b/example_project/mappers/Baseline.rb
@@ -432,6 +432,12 @@ module URBANopt
 
             args = {}
 
+            # Custom HPXML Files
+            begin
+              args[:hpxml_directory] = feature.hpxml_directory
+            rescue
+            end
+
             # Simulation Control
             args[:simulation_control_timestep] = 60
             begin
@@ -712,7 +718,7 @@ module URBANopt
 
             args.keys.each do |arg_name|
               unless default_args.keys.include? arg_name
-                next if [:feature_id, :schedules_type, :schedules_variation, :geometry_num_floors_above_grade].include?(arg_name)
+                next if [:feature_id, :schedules_type, :schedules_variation, :geometry_num_floors_above_grade, :hpxml_directory].include?(arg_name)
 
                 puts "Argument '#{arg_name}' is unknown."
               end

--- a/example_project/mappers/Baseline.rb
+++ b/example_project/mappers/Baseline.rb
@@ -434,7 +434,7 @@ module URBANopt
 
             # Custom HPXML Files
             begin
-              args[:hpxml_directory] = feature.hpxml_directory
+              args[:hpxml_dir] = feature.hpxml_directory
             rescue
             end
 
@@ -545,7 +545,8 @@ module URBANopt
               feature_ids << feature.id
             end
 
-            args[:feature_id] = feature_ids.index(feature_id)
+            args[:feature_id] = feature_id
+            args[:schedules_random_seed] = feature_ids.index(feature_id)
             args[:schedules_type] = 'stochastic' # smooth or stochastic
             args[:schedules_variation] = 'unit' # building or unit
 
@@ -718,7 +719,7 @@ module URBANopt
 
             args.keys.each do |arg_name|
               unless default_args.keys.include? arg_name
-                next if [:feature_id, :schedules_type, :schedules_variation, :geometry_num_floors_above_grade, :hpxml_directory].include?(arg_name)
+                next if [:feature_id, :schedules_type, :schedules_random_seed, :schedules_variation, :geometry_num_floors_above_grade, :hpxml_dir].include?(arg_name)
 
                 puts "Argument '#{arg_name}' is unknown."
               end

--- a/example_project/measures/BuildResidentialModel/measure.rb
+++ b/example_project/measures/BuildResidentialModel/measure.rb
@@ -49,6 +49,12 @@ class BuildResidentialModel < OpenStudio::Measure::ModelMeasure
     arg.setDefaultValue('smooth')
     args << arg
 
+    arg = OpenStudio::Measure::OSArgument.makeIntegerArgument('schedules_random_seed', true)
+    arg.setDisplayName('Schedules: Random Seed')
+    arg.setUnits('#')
+    arg.setDescription("This numeric field is the seed for the random number generator. Only applies if the schedules type is 'stochastic'.")
+    args << arg
+
     schedules_variation_choices = OpenStudio::StringVector.new
     schedules_variation_choices << 'unit'
     schedules_variation_choices << 'building'
@@ -61,12 +67,12 @@ class BuildResidentialModel < OpenStudio::Measure::ModelMeasure
     arg = OpenStudio::Measure::OSArgument::makeIntegerArgument('geometry_num_floors_above_grade', true)
     arg.setDisplayName('Geometry: Number of Floors Above Grade')
     arg.setUnits('#')
-    arg.setDescription("The number of floors above grade.")
+    arg.setDescription('The number of floors above grade.')
     args << arg
 
-    arg = OpenStudio::Measure::OSArgument::makeStringArgument('hpxml_directory', false)
+    arg = OpenStudio::Measure::OSArgument::makeStringArgument('hpxml_dir', false)
     arg.setDisplayName('Custom HPXML Files')
-    arg.setDescription("TODO.")
+    arg.setDescription('The name of the folder containing HPXML files, relative to the xml_building folder.')
     args << arg
 
     measures_dir = File.absolute_path(File.join(File.dirname(__FILE__), '../../resources/hpxml-measures'))
@@ -124,14 +130,21 @@ class BuildResidentialModel < OpenStudio::Measure::ModelMeasure
     model.getTimestep.remove
 
     # either create units or get pre-made units
-    if args['hpxml_directory'].nil?
+    if args['hpxml_dir'].nil?
       units = get_unit_positions(runner, args)
       if units.empty?
         return false
       end
     else
+      hpxml_dir = File.join(File.dirname(__FILE__), "../../xml_building/#{args['hpxml_dir']}")
+
+      if !File.exist?(hpxml_dir)
+        runner.registerError("HPXML directory #{File.expand_path(hpxml_dir)} was specified for feature ID = #{args['feature_id']}, but could not be found.")
+        return false
+      end
+
       units = []
-      Dir[File.join(File.dirname(__FILE__), "../../xml_building/#{args['hpxml_directory']}/*.xml")].each do |hpxml_path|
+      Dir["#{hpxml_dir}/*.xml"].each do |hpxml_path|
         name, ext = File.basename(hpxml_path).split('.')
         units << {'name' => name, 'hpxml_path' => hpxml_path}
       end
@@ -178,6 +191,7 @@ class BuildResidentialModel < OpenStudio::Measure::ModelMeasure
         measure_args['geometry_unit_orientation'] = unit['geometry_unit_orientation'] if unit.keys.include?('geometry_unit_orientation')
         measure_args.delete('feature_id')
         measure_args.delete('schedules_type')
+        measure_args.delete('schedules_random_seed')
         measure_args.delete('schedules_variation')
         measure_args.delete('geometry_num_floors_above_grade')
 
@@ -196,7 +210,7 @@ class BuildResidentialModel < OpenStudio::Measure::ModelMeasure
       measure_args['hpxml_path'] = hpxml_path
       measure_args['hpxml_output_path'] = hpxml_path
       measure_args['schedules_type'] = args['schedules_type']
-      measure_args['schedules_random_seed'] = args['feature_id'] # variation by building; deterministic
+      measure_args['schedules_random_seed'] = args['schedules_random_seed'] # variation by building; deterministic
       if args['schedules_variation'] == 'unit' 
         measure_args['schedules_random_seed'] *= (unit_num + 1) # variation across units; deterministic
       end

--- a/example_project/measures/BuildResidentialModel/measure.xml
+++ b/example_project/measures/BuildResidentialModel/measure.xml
@@ -3,8 +3,8 @@
   <schema_version>3.0</schema_version>
   <name>build_residential_model</name>
   <uid>259dc35f-65e8-47d4-913f-69efede5a267</uid>
-  <version_id>4b1a5ba1-4a8f-4956-913a-085eff8469c7</version_id>
-  <version_modified>20220228T220931Z</version_modified>
+  <version_id>d1ed2d57-8e96-4f88-94b0-78508dd6afc5</version_id>
+  <version_modified>20220302T215635Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialModel</class_name>
   <display_name>Build Residential Model</display_name>
@@ -39,6 +39,15 @@
       </choices>
     </argument>
     <argument>
+      <name>schedules_random_seed</name>
+      <display_name>Schedules: Random Seed</display_name>
+      <description>This numeric field is the seed for the random number generator. Only applies if the schedules type is 'stochastic'.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
       <name>schedules_variation</name>
       <display_name>Schedules: Variation</display_name>
       <description>How the schedules vary.</description>
@@ -66,9 +75,9 @@
       <model_dependent>false</model_dependent>
     </argument>
     <argument>
-      <name>hpxml_directory</name>
+      <name>hpxml_dir</name>
       <display_name>Custom HPXML Files</display_name>
-      <description>TODO.</description>
+      <description>The name of the folder containing HPXML files, relative to the xml_building folder.</description>
       <type>String</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
@@ -5949,17 +5958,6 @@
   </attributes>
   <files>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>2.9.1</identifier>
-        <min_compatible>2.9.1</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>2157707D</checksum>
-    </file>
-    <file>
       <filename>constants.rb</filename>
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
@@ -5982,6 +5980,17 @@
       <filetype>rb</filetype>
       <usage_type>resource</usage_type>
       <checksum>ECE5603C</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>2.9.1</identifier>
+        <min_compatible>2.9.1</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>41DA52D8</checksum>
     </file>
   </files>
 </measure>

--- a/example_project/measures/BuildResidentialModel/measure.xml
+++ b/example_project/measures/BuildResidentialModel/measure.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0"?>
 <measure>
   <schema_version>3.0</schema_version>
   <name>build_residential_model</name>
   <uid>259dc35f-65e8-47d4-913f-69efede5a267</uid>
-  <version_id>22176a3d-cb26-48b7-85d0-ba9c5e7fdd77</version_id>
-  <version_modified>20200102T175052Z</version_modified>
+  <version_id>4b1a5ba1-4a8f-4956-913a-085eff8469c7</version_id>
+  <version_modified>20220228T220931Z</version_modified>
   <xml_checksum>2C38F48B</xml_checksum>
   <class_name>BuildResidentialModel</class_name>
   <display_name>Build Residential Model</display_name>
@@ -11,32 +12,5931 @@
   <modeler_description>Builds the residential OpenStudio Model using the geojson feature file, which contains the specified parameters for each existing building.</modeler_description>
   <arguments>
     <argument>
-      <name>building_type</name>
-      <display_name>Building Type</display_name>
-      <description>The type of the residential building.</description>
-      <type>String</type>
-      <required>true</required>
-      <model_dependent>false</model_dependent>
-    </argument>
-    <argument>
-      <name>footprint_area</name>
-      <display_name>Footpring Area</display_name>
-      <description>The footprint area of the residential building.</description>
-      <type>Double</type>
-      <required>true</required>
-      <model_dependent>false</model_dependent>
-    </argument>
-    <argument>
-      <name>number_of_stories</name>
-      <display_name>Number of Stories</display_name>
-      <description>The number of stories of the residential building.</description>
+      <name>feature_id</name>
+      <display_name>Feature ID</display_name>
+      <description>The feature ID passed from Baseline.rb.</description>
       <type>Integer</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
     </argument>
+    <argument>
+      <name>schedules_type</name>
+      <display_name>Schedules: Type</display_name>
+      <description>The type of occupant-related schedules to use.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>smooth</default_value>
+      <choices>
+        <choice>
+          <value>smooth</value>
+          <display_name>smooth</display_name>
+        </choice>
+        <choice>
+          <value>stochastic</value>
+          <display_name>stochastic</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>schedules_variation</name>
+      <display_name>Schedules: Variation</display_name>
+      <description>How the schedules vary.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>unit</value>
+          <display_name>unit</display_name>
+        </choice>
+        <choice>
+          <value>building</value>
+          <display_name>building</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_num_floors_above_grade</name>
+      <display_name>Geometry: Number of Floors Above Grade</display_name>
+      <description>The number of floors above grade.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>hpxml_directory</name>
+      <display_name>Custom HPXML Files</display_name>
+      <description>TODO.</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>software_info_program_used</name>
+      <display_name>Software Info: Program Used</display_name>
+      <description>The name of the software program used.</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>software_info_program_version</name>
+      <display_name>Software Info: Program Version</display_name>
+      <description>The version of the software program used.</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>simulation_control_timestep</name>
+      <display_name>Simulation Control: Timestep</display_name>
+      <description>Value must be a divisor of 60.</description>
+      <type>Integer</type>
+      <units>min</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>simulation_control_run_period</name>
+      <display_name>Simulation Control: Run Period</display_name>
+      <description>Enter a date like "Jan 1 - Dec 31".</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>simulation_control_run_period_calendar_year</name>
+      <display_name>Simulation Control: Run Period Calendar Year</display_name>
+      <description>This numeric field should contain the calendar year that determines the start day of week. If you are running simulations using AMY weather files, the value entered for calendar year will not be used; it will be overridden by the actual year found in the AMY weather file.</description>
+      <type>Integer</type>
+      <units>year</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>simulation_control_daylight_saving_enabled</name>
+      <display_name>Simulation Control: Daylight Saving Enabled</display_name>
+      <description>Whether to use daylight saving.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>simulation_control_daylight_saving_period</name>
+      <display_name>Simulation Control: Daylight Saving Period</display_name>
+      <description>Enter a date like "Mar 15 - Dec 15".</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>site_type</name>
+      <display_name>Site: Type</display_name>
+      <description>The type of site.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>suburban</value>
+          <display_name>suburban</display_name>
+        </choice>
+        <choice>
+          <value>urban</value>
+          <display_name>urban</display_name>
+        </choice>
+        <choice>
+          <value>rural</value>
+          <display_name>rural</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>site_shielding_of_home</name>
+      <display_name>Site: Shielding of Home</display_name>
+      <description>Presence of nearby buildings, trees, obstructions for infiltration model.  A value of 'auto' will use 'normal'.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>exposed</value>
+          <display_name>exposed</display_name>
+        </choice>
+        <choice>
+          <value>normal</value>
+          <display_name>normal</display_name>
+        </choice>
+        <choice>
+          <value>well-shielded</value>
+          <display_name>well-shielded</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>zip_code</name>
+      <display_name>Zip Code</display_name>
+      <description>Zip code - used for informational purposes only</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>site_iecc_zone</name>
+      <display_name>Site: IECC Zone</display_name>
+      <description>IECC zone of the home address. If not provided, uses the IECC zone corresponding to the EPW weather file.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>1A</value>
+          <display_name>1A</display_name>
+        </choice>
+        <choice>
+          <value>1B</value>
+          <display_name>1B</display_name>
+        </choice>
+        <choice>
+          <value>1C</value>
+          <display_name>1C</display_name>
+        </choice>
+        <choice>
+          <value>2A</value>
+          <display_name>2A</display_name>
+        </choice>
+        <choice>
+          <value>2B</value>
+          <display_name>2B</display_name>
+        </choice>
+        <choice>
+          <value>2C</value>
+          <display_name>2C</display_name>
+        </choice>
+        <choice>
+          <value>3A</value>
+          <display_name>3A</display_name>
+        </choice>
+        <choice>
+          <value>3B</value>
+          <display_name>3B</display_name>
+        </choice>
+        <choice>
+          <value>3C</value>
+          <display_name>3C</display_name>
+        </choice>
+        <choice>
+          <value>4A</value>
+          <display_name>4A</display_name>
+        </choice>
+        <choice>
+          <value>4B</value>
+          <display_name>4B</display_name>
+        </choice>
+        <choice>
+          <value>4C</value>
+          <display_name>4C</display_name>
+        </choice>
+        <choice>
+          <value>5A</value>
+          <display_name>5A</display_name>
+        </choice>
+        <choice>
+          <value>5B</value>
+          <display_name>5B</display_name>
+        </choice>
+        <choice>
+          <value>5C</value>
+          <display_name>5C</display_name>
+        </choice>
+        <choice>
+          <value>6A</value>
+          <display_name>6A</display_name>
+        </choice>
+        <choice>
+          <value>6B</value>
+          <display_name>6B</display_name>
+        </choice>
+        <choice>
+          <value>6C</value>
+          <display_name>6C</display_name>
+        </choice>
+        <choice>
+          <value>7</value>
+          <display_name>7</display_name>
+        </choice>
+        <choice>
+          <value>8</value>
+          <display_name>8</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>site_state_code</name>
+      <display_name>Site: State Code</display_name>
+      <description>State code of the home address. If not provided, uses the EPW weather file state code.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>AK</value>
+          <display_name>AK</display_name>
+        </choice>
+        <choice>
+          <value>AL</value>
+          <display_name>AL</display_name>
+        </choice>
+        <choice>
+          <value>AR</value>
+          <display_name>AR</display_name>
+        </choice>
+        <choice>
+          <value>AZ</value>
+          <display_name>AZ</display_name>
+        </choice>
+        <choice>
+          <value>CA</value>
+          <display_name>CA</display_name>
+        </choice>
+        <choice>
+          <value>CO</value>
+          <display_name>CO</display_name>
+        </choice>
+        <choice>
+          <value>CT</value>
+          <display_name>CT</display_name>
+        </choice>
+        <choice>
+          <value>DC</value>
+          <display_name>DC</display_name>
+        </choice>
+        <choice>
+          <value>DE</value>
+          <display_name>DE</display_name>
+        </choice>
+        <choice>
+          <value>FL</value>
+          <display_name>FL</display_name>
+        </choice>
+        <choice>
+          <value>GA</value>
+          <display_name>GA</display_name>
+        </choice>
+        <choice>
+          <value>HI</value>
+          <display_name>HI</display_name>
+        </choice>
+        <choice>
+          <value>IA</value>
+          <display_name>IA</display_name>
+        </choice>
+        <choice>
+          <value>ID</value>
+          <display_name>ID</display_name>
+        </choice>
+        <choice>
+          <value>IL</value>
+          <display_name>IL</display_name>
+        </choice>
+        <choice>
+          <value>IN</value>
+          <display_name>IN</display_name>
+        </choice>
+        <choice>
+          <value>KS</value>
+          <display_name>KS</display_name>
+        </choice>
+        <choice>
+          <value>KY</value>
+          <display_name>KY</display_name>
+        </choice>
+        <choice>
+          <value>LA</value>
+          <display_name>LA</display_name>
+        </choice>
+        <choice>
+          <value>MA</value>
+          <display_name>MA</display_name>
+        </choice>
+        <choice>
+          <value>MD</value>
+          <display_name>MD</display_name>
+        </choice>
+        <choice>
+          <value>ME</value>
+          <display_name>ME</display_name>
+        </choice>
+        <choice>
+          <value>MI</value>
+          <display_name>MI</display_name>
+        </choice>
+        <choice>
+          <value>MN</value>
+          <display_name>MN</display_name>
+        </choice>
+        <choice>
+          <value>MO</value>
+          <display_name>MO</display_name>
+        </choice>
+        <choice>
+          <value>MS</value>
+          <display_name>MS</display_name>
+        </choice>
+        <choice>
+          <value>MT</value>
+          <display_name>MT</display_name>
+        </choice>
+        <choice>
+          <value>NC</value>
+          <display_name>NC</display_name>
+        </choice>
+        <choice>
+          <value>ND</value>
+          <display_name>ND</display_name>
+        </choice>
+        <choice>
+          <value>NE</value>
+          <display_name>NE</display_name>
+        </choice>
+        <choice>
+          <value>NH</value>
+          <display_name>NH</display_name>
+        </choice>
+        <choice>
+          <value>NJ</value>
+          <display_name>NJ</display_name>
+        </choice>
+        <choice>
+          <value>NM</value>
+          <display_name>NM</display_name>
+        </choice>
+        <choice>
+          <value>NV</value>
+          <display_name>NV</display_name>
+        </choice>
+        <choice>
+          <value>NY</value>
+          <display_name>NY</display_name>
+        </choice>
+        <choice>
+          <value>OH</value>
+          <display_name>OH</display_name>
+        </choice>
+        <choice>
+          <value>OK</value>
+          <display_name>OK</display_name>
+        </choice>
+        <choice>
+          <value>OR</value>
+          <display_name>OR</display_name>
+        </choice>
+        <choice>
+          <value>PA</value>
+          <display_name>PA</display_name>
+        </choice>
+        <choice>
+          <value>RI</value>
+          <display_name>RI</display_name>
+        </choice>
+        <choice>
+          <value>SC</value>
+          <display_name>SC</display_name>
+        </choice>
+        <choice>
+          <value>SD</value>
+          <display_name>SD</display_name>
+        </choice>
+        <choice>
+          <value>TN</value>
+          <display_name>TN</display_name>
+        </choice>
+        <choice>
+          <value>TX</value>
+          <display_name>TX</display_name>
+        </choice>
+        <choice>
+          <value>UT</value>
+          <display_name>UT</display_name>
+        </choice>
+        <choice>
+          <value>VA</value>
+          <display_name>VA</display_name>
+        </choice>
+        <choice>
+          <value>VT</value>
+          <display_name>VT</display_name>
+        </choice>
+        <choice>
+          <value>WA</value>
+          <display_name>WA</display_name>
+        </choice>
+        <choice>
+          <value>WI</value>
+          <display_name>WI</display_name>
+        </choice>
+        <choice>
+          <value>WV</value>
+          <display_name>WV</display_name>
+        </choice>
+        <choice>
+          <value>WY</value>
+          <display_name>WY</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>weather_station_epw_filepath</name>
+      <display_name>Weather Station: EnergyPlus Weather (EPW) Filepath</display_name>
+      <description>Path of the EPW file.</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>USA_CO_Denver.Intl.AP.725650_TMY3.epw</default_value>
+    </argument>
+    <argument>
+      <name>year_built</name>
+      <display_name>Building Construction: Year Built</display_name>
+      <description>The year the building was built</description>
+      <type>Integer</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>geometry_unit_type</name>
+      <display_name>Geometry: Unit Type</display_name>
+      <description>The type of dwelling unit. Use single-family attached for a dwelling unit with 1 or more stories, attached units to one or both sides, and no units above/below. Use apartment unit for a dwelling unit with 1 story, attached units to one, two, or three sides, and units above and/or below.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>single-family detached</default_value>
+      <choices>
+        <choice>
+          <value>single-family detached</value>
+          <display_name>single-family detached</display_name>
+        </choice>
+        <choice>
+          <value>single-family attached</value>
+          <display_name>single-family attached</display_name>
+        </choice>
+        <choice>
+          <value>apartment unit</value>
+          <display_name>apartment unit</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_unit_left_wall_is_adiabatic</name>
+      <display_name>Geometry: Unit Left Wall Is Adiabatic</display_name>
+      <description>Presence of an adiabatic left wall.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_unit_right_wall_is_adiabatic</name>
+      <display_name>Geometry: Unit Right Wall Is Adiabatic</display_name>
+      <description>Presence of an adiabatic right wall.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_unit_front_wall_is_adiabatic</name>
+      <display_name>Geometry: Unit Front Wall Is Adiabatic</display_name>
+      <description>Presence of an adiabatic front wall, for example, the unit is adjacent to a conditioned corridor.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_unit_back_wall_is_adiabatic</name>
+      <display_name>Geometry: Unit Back Wall Is Adiabatic</display_name>
+      <description>Presence of an adiabatic back wall.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_unit_num_floors_above_grade</name>
+      <display_name>Geometry: Unit Number of Floors Above Grade</display_name>
+      <description>The number of floors above grade in the unit. Conditioned attics are included. Assumed to be 1 if apartment unit.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>2</default_value>
+    </argument>
+    <argument>
+      <name>geometry_unit_cfa</name>
+      <display_name>Geometry: Unit Conditioned Floor Area</display_name>
+      <description>The total floor area of the unit's conditioned space (including any conditioned basement floor area).</description>
+      <type>Double</type>
+      <units>ft^2</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>2000</default_value>
+    </argument>
+    <argument>
+      <name>geometry_unit_aspect_ratio</name>
+      <display_name>Geometry: Unit Aspect Ratio</display_name>
+      <description>The ratio of front/back wall length to left/right wall length for the unit, excluding any protruding garage wall area.</description>
+      <type>Double</type>
+      <units>FB/LR</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>2</default_value>
+    </argument>
+    <argument>
+      <name>geometry_unit_orientation</name>
+      <display_name>Geometry: Unit Orientation</display_name>
+      <description>The unit's orientation is measured clockwise from north (e.g., North=0, East=90, South=180, West=270).</description>
+      <type>Double</type>
+      <units>degrees</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>180</default_value>
+    </argument>
+    <argument>
+      <name>geometry_unit_num_bedrooms</name>
+      <display_name>Geometry: Unit Number of Bedrooms</display_name>
+      <description>The number of bedrooms in the unit. Used to determine the energy usage of appliances and plug loads, hot water usage, etc.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>3</default_value>
+    </argument>
+    <argument>
+      <name>geometry_unit_num_bathrooms</name>
+      <display_name>Geometry: Unit Number of Bathrooms</display_name>
+      <description>The number of bathrooms in the unit.  A value of 'auto' will default the value based on the number of bedrooms.</description>
+      <type>String</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>geometry_unit_num_occupants</name>
+      <display_name>Geometry: Unit Number of Occupants</display_name>
+      <description>The number of occupants in the unit. A value of 'auto' will default the value based on the number of bedrooms. Used to specify the internal gains from people only.</description>
+      <type>String</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>geometry_building_num_units</name>
+      <display_name>Geometry: Building Number of Units</display_name>
+      <description>The number of units in the building. This is required for single-family attached and apartment units.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>geometry_average_ceiling_height</name>
+      <display_name>Geometry: Average Ceiling Height</display_name>
+      <description>Average distance from the floor to the ceiling.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>8</default_value>
+    </argument>
+    <argument>
+      <name>geometry_garage_width</name>
+      <display_name>Geometry: Garage Width</display_name>
+      <description>The width of the garage. Enter zero for no garage. Only applies to single-family detached units.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>geometry_garage_depth</name>
+      <display_name>Geometry: Garage Depth</display_name>
+      <description>The depth of the garage. Only applies to single-family detached units.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>20</default_value>
+    </argument>
+    <argument>
+      <name>geometry_garage_protrusion</name>
+      <display_name>Geometry: Garage Protrusion</display_name>
+      <description>The fraction of the garage that is protruding from the living space. Only applies to single-family detached units.</description>
+      <type>Double</type>
+      <units>frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>geometry_garage_position</name>
+      <display_name>Geometry: Garage Position</display_name>
+      <description>The position of the garage. Only applies to single-family detached units.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>Right</default_value>
+      <choices>
+        <choice>
+          <value>Right</value>
+          <display_name>Right</display_name>
+        </choice>
+        <choice>
+          <value>Left</value>
+          <display_name>Left</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_foundation_type</name>
+      <display_name>Geometry: Foundation Type</display_name>
+      <description>The foundation type of the building.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>SlabOnGrade</default_value>
+      <choices>
+        <choice>
+          <value>SlabOnGrade</value>
+          <display_name>SlabOnGrade</display_name>
+        </choice>
+        <choice>
+          <value>VentedCrawlspace</value>
+          <display_name>VentedCrawlspace</display_name>
+        </choice>
+        <choice>
+          <value>UnventedCrawlspace</value>
+          <display_name>UnventedCrawlspace</display_name>
+        </choice>
+        <choice>
+          <value>ConditionedCrawlspace</value>
+          <display_name>ConditionedCrawlspace</display_name>
+        </choice>
+        <choice>
+          <value>UnconditionedBasement</value>
+          <display_name>UnconditionedBasement</display_name>
+        </choice>
+        <choice>
+          <value>ConditionedBasement</value>
+          <display_name>ConditionedBasement</display_name>
+        </choice>
+        <choice>
+          <value>Ambient</value>
+          <display_name>Ambient</display_name>
+        </choice>
+        <choice>
+          <value>AboveApartment</value>
+          <display_name>AboveApartment</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_foundation_height</name>
+      <display_name>Geometry: Foundation Height</display_name>
+      <description>The height of the foundation (e.g., 3ft for crawlspace, 8ft for basement). Only applies to basements/crawlspaces.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>geometry_foundation_height_above_grade</name>
+      <display_name>Geometry: Foundation Height Above Grade</display_name>
+      <description>The depth above grade of the foundation wall. Only applies to basements/crawlspaces.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>geometry_rim_joist_height</name>
+      <display_name>Geometry: Rim Joist Height</display_name>
+      <description>The height of the rim joists. Only applies to basements/crawlspaces.</description>
+      <type>Double</type>
+      <units>in</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>geometry_attic_type</name>
+      <display_name>Geometry: Attic Type</display_name>
+      <description>The attic type of the building.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>VentedAttic</default_value>
+      <choices>
+        <choice>
+          <value>FlatRoof</value>
+          <display_name>FlatRoof</display_name>
+        </choice>
+        <choice>
+          <value>VentedAttic</value>
+          <display_name>VentedAttic</display_name>
+        </choice>
+        <choice>
+          <value>UnventedAttic</value>
+          <display_name>UnventedAttic</display_name>
+        </choice>
+        <choice>
+          <value>ConditionedAttic</value>
+          <display_name>ConditionedAttic</display_name>
+        </choice>
+        <choice>
+          <value>BelowApartment</value>
+          <display_name>BelowApartment</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_roof_type</name>
+      <display_name>Geometry: Roof Type</display_name>
+      <description>The roof type of the building. Ignored if the building has a flat roof.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>gable</default_value>
+      <choices>
+        <choice>
+          <value>gable</value>
+          <display_name>gable</display_name>
+        </choice>
+        <choice>
+          <value>hip</value>
+          <display_name>hip</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_roof_pitch</name>
+      <display_name>Geometry: Roof Pitch</display_name>
+      <description>The roof pitch of the attic. Ignored if the building has a flat roof.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>6:12</default_value>
+      <choices>
+        <choice>
+          <value>1:12</value>
+          <display_name>1:12</display_name>
+        </choice>
+        <choice>
+          <value>2:12</value>
+          <display_name>2:12</display_name>
+        </choice>
+        <choice>
+          <value>3:12</value>
+          <display_name>3:12</display_name>
+        </choice>
+        <choice>
+          <value>4:12</value>
+          <display_name>4:12</display_name>
+        </choice>
+        <choice>
+          <value>5:12</value>
+          <display_name>5:12</display_name>
+        </choice>
+        <choice>
+          <value>6:12</value>
+          <display_name>6:12</display_name>
+        </choice>
+        <choice>
+          <value>7:12</value>
+          <display_name>7:12</display_name>
+        </choice>
+        <choice>
+          <value>8:12</value>
+          <display_name>8:12</display_name>
+        </choice>
+        <choice>
+          <value>9:12</value>
+          <display_name>9:12</display_name>
+        </choice>
+        <choice>
+          <value>10:12</value>
+          <display_name>10:12</display_name>
+        </choice>
+        <choice>
+          <value>11:12</value>
+          <display_name>11:12</display_name>
+        </choice>
+        <choice>
+          <value>12:12</value>
+          <display_name>12:12</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>geometry_eaves_depth</name>
+      <display_name>Geometry: Eaves Depth</display_name>
+      <description>The eaves depth of the roof.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>2</default_value>
+    </argument>
+    <argument>
+      <name>geometry_has_flue_or_chimney</name>
+      <display_name>Geometry: Has Flue or Chimney</display_name>
+      <description>Presence of flue or chimney for infiltration model.  A value of 'auto' will default based on the fuel type and efficiency of space/water heating equipment in the home.</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_front_distance</name>
+      <display_name>Neighbor: Front Distance</display_name>
+      <description>The distance between the unit and the neighboring building to the front (not including eaves). A value of zero indicates no neighbors. Used for shading.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_back_distance</name>
+      <display_name>Neighbor: Back Distance</display_name>
+      <description>The distance between the unit and the neighboring building to the back (not including eaves). A value of zero indicates no neighbors. Used for shading.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_left_distance</name>
+      <display_name>Neighbor: Left Distance</display_name>
+      <description>The distance between the unit and the neighboring building to the left (not including eaves). A value of zero indicates no neighbors. Used for shading.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>10</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_right_distance</name>
+      <display_name>Neighbor: Right Distance</display_name>
+      <description>The distance between the unit and the neighboring building to the right (not including eaves). A value of zero indicates no neighbors. Used for shading.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>10</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_front_height</name>
+      <display_name>Neighbor: Front Height</display_name>
+      <description>The height of the neighboring building to the front. A value of 'auto' will use the same height as this building.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_back_height</name>
+      <display_name>Neighbor: Back Height</display_name>
+      <description>The height of the neighboring building to the back. A value of 'auto' will use the same height as this building.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_left_height</name>
+      <display_name>Neighbor: Left Height</display_name>
+      <description>The height of the neighboring building to the left. A value of 'auto' will use the same height as this building.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>neighbor_right_height</name>
+      <display_name>Neighbor: Right Height</display_name>
+      <description>The height of the neighboring building to the right. A value of 'auto' will use the same height as this building.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>floor_over_foundation_assembly_r</name>
+      <display_name>Floor: Over Foundation Assembly R-value</display_name>
+      <description>Assembly R-value for the floor over the foundation. Ignored if the building has a slab-on-grade foundation.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>28.1</default_value>
+    </argument>
+    <argument>
+      <name>floor_over_garage_assembly_r</name>
+      <display_name>Floor: Over Garage Assembly R-value</display_name>
+      <description>Assembly R-value for the floor over the garage. Ignored unless the building has a garage under conditioned space.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>28.1</default_value>
+    </argument>
+    <argument>
+      <name>foundation_wall_type</name>
+      <display_name>Foundation Wall: Type</display_name>
+      <description>The material type of the foundation wall.</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>foundation_wall_thickness</name>
+      <display_name>Foundation Wall: Thickness</display_name>
+      <description>The thickness of the foundation wall.</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>foundation_wall_insulation_r</name>
+      <display_name>Foundation Wall: Insulation Nominal R-value</display_name>
+      <description>Nominal R-value for the foundation wall insulation. Only applies to basements/crawlspaces.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>foundation_wall_insulation_location</name>
+      <display_name>Foundation Wall: Insulation Location</display_name>
+      <description>Whether the insulation is on the interior or exterior of the foundation wall. Only applies to basements/crawlspaces.</description>
+      <type>Choice</type>
+      <units>ft</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>exterior</default_value>
+      <choices>
+        <choice>
+          <value>interior</value>
+          <display_name>interior</display_name>
+        </choice>
+        <choice>
+          <value>exterior</value>
+          <display_name>exterior</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>foundation_wall_insulation_distance_to_top</name>
+      <display_name>Foundation Wall: Insulation Distance To Top</display_name>
+      <description>The distance from the top of the foundation wall to the top of the foundation wall insulation. Only applies to basements/crawlspaces. A value of 'auto' will use zero.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>foundation_wall_insulation_distance_to_bottom</name>
+      <display_name>Foundation Wall: Insulation Distance To Bottom</display_name>
+      <description>The distance from the top of the foundation wall to the bottom of the foundation wall insulation. Only applies to basements/crawlspaces. A value of 'auto' will use the height of the foundation wall.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>foundation_wall_assembly_r</name>
+      <display_name>Foundation Wall: Assembly R-value</display_name>
+      <description>Assembly R-value for the foundation walls. Only applies to basements/crawlspaces. If provided, overrides the previous foundation wall insulation inputs.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>rim_joist_assembly_r</name>
+      <display_name>Rim Joist: Assembly R-value</display_name>
+      <description>Assembly R-value for the rim joists. Only applies to basements/crawlspaces.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>slab_perimeter_insulation_r</name>
+      <display_name>Slab: Perimeter Insulation Nominal R-value</display_name>
+      <description>Nominal R-value of the vertical slab perimeter insulation. Applies to slab-on-grade foundations and basement/crawlspace floors.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>slab_perimeter_depth</name>
+      <display_name>Slab: Perimeter Insulation Depth</display_name>
+      <description>Depth from grade to bottom of vertical slab perimeter insulation. Applies to slab-on-grade foundations and basement/crawlspace floors.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>slab_under_insulation_r</name>
+      <display_name>Slab: Under Slab Insulation Nominal R-value</display_name>
+      <description>Nominal R-value of the horizontal under slab insulation. Applies to slab-on-grade foundations and basement/crawlspace floors.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>slab_under_width</name>
+      <display_name>Slab: Under Slab Insulation Width</display_name>
+      <description>Width from slab edge inward of horizontal under-slab insulation. Enter 999 to specify that the under slab insulation spans the entire slab. Applies to slab-on-grade foundations and basement/crawlspace floors.</description>
+      <type>Double</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>slab_thickness</name>
+      <display_name>Slab: Thickness</display_name>
+      <description>The thickness of the slab. Zero can be entered if there is a dirt floor instead of a slab.</description>
+      <type>String</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>slab_carpet_fraction</name>
+      <display_name>Slab: Carpet Fraction</display_name>
+      <description>Fraction of the slab floor area that is carpeted.</description>
+      <type>String</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>slab_carpet_r</name>
+      <display_name>Slab: Carpet R-value</display_name>
+      <description>R-value of the slab carpet.</description>
+      <type>String</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>ceiling_assembly_r</name>
+      <display_name>Ceiling: Assembly R-value</display_name>
+      <description>Assembly R-value for the ceiling (attic floor).</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>31.6</default_value>
+    </argument>
+    <argument>
+      <name>roof_material_type</name>
+      <display_name>Roof: Material Type</display_name>
+      <description>The material type of the roof.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>asphalt or fiberglass shingles</value>
+          <display_name>asphalt or fiberglass shingles</display_name>
+        </choice>
+        <choice>
+          <value>concrete</value>
+          <display_name>concrete</display_name>
+        </choice>
+        <choice>
+          <value>cool roof</value>
+          <display_name>cool roof</display_name>
+        </choice>
+        <choice>
+          <value>slate or tile shingles</value>
+          <display_name>slate or tile shingles</display_name>
+        </choice>
+        <choice>
+          <value>expanded polystyrene sheathing</value>
+          <display_name>expanded polystyrene sheathing</display_name>
+        </choice>
+        <choice>
+          <value>metal surfacing</value>
+          <display_name>metal surfacing</display_name>
+        </choice>
+        <choice>
+          <value>plastic/rubber/synthetic sheeting</value>
+          <display_name>plastic/rubber/synthetic sheeting</display_name>
+        </choice>
+        <choice>
+          <value>shingles</value>
+          <display_name>shingles</display_name>
+        </choice>
+        <choice>
+          <value>wood shingles or shakes</value>
+          <display_name>wood shingles or shakes</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>roof_color</name>
+      <display_name>Roof: Color</display_name>
+      <description>The color of the roof.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>medium</default_value>
+      <choices>
+        <choice>
+          <value>dark</value>
+          <display_name>dark</display_name>
+        </choice>
+        <choice>
+          <value>light</value>
+          <display_name>light</display_name>
+        </choice>
+        <choice>
+          <value>medium</value>
+          <display_name>medium</display_name>
+        </choice>
+        <choice>
+          <value>medium dark</value>
+          <display_name>medium dark</display_name>
+        </choice>
+        <choice>
+          <value>reflective</value>
+          <display_name>reflective</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>roof_assembly_r</name>
+      <display_name>Roof: Assembly R-value</display_name>
+      <description>Assembly R-value of the roof.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>2.3</default_value>
+    </argument>
+    <argument>
+      <name>roof_radiant_barrier</name>
+      <display_name>Roof: Has Radiant Barrier</display_name>
+      <description>Presence of a radiant barrier in the attic.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>roof_radiant_barrier_grade</name>
+      <display_name>Roof: Radiant Barrier Grade</display_name>
+      <description>The grade of the radiant barrier, if it exists.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+      <choices>
+        <choice>
+          <value>1</value>
+          <display_name>1</display_name>
+        </choice>
+        <choice>
+          <value>2</value>
+          <display_name>2</display_name>
+        </choice>
+        <choice>
+          <value>3</value>
+          <display_name>3</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>wall_type</name>
+      <display_name>Wall: Type</display_name>
+      <description>The type of walls.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>WoodStud</default_value>
+      <choices>
+        <choice>
+          <value>WoodStud</value>
+          <display_name>WoodStud</display_name>
+        </choice>
+        <choice>
+          <value>ConcreteMasonryUnit</value>
+          <display_name>ConcreteMasonryUnit</display_name>
+        </choice>
+        <choice>
+          <value>DoubleWoodStud</value>
+          <display_name>DoubleWoodStud</display_name>
+        </choice>
+        <choice>
+          <value>InsulatedConcreteForms</value>
+          <display_name>InsulatedConcreteForms</display_name>
+        </choice>
+        <choice>
+          <value>LogWall</value>
+          <display_name>LogWall</display_name>
+        </choice>
+        <choice>
+          <value>StructurallyInsulatedPanel</value>
+          <display_name>StructurallyInsulatedPanel</display_name>
+        </choice>
+        <choice>
+          <value>SolidConcrete</value>
+          <display_name>SolidConcrete</display_name>
+        </choice>
+        <choice>
+          <value>SteelFrame</value>
+          <display_name>SteelFrame</display_name>
+        </choice>
+        <choice>
+          <value>Stone</value>
+          <display_name>Stone</display_name>
+        </choice>
+        <choice>
+          <value>StrawBale</value>
+          <display_name>StrawBale</display_name>
+        </choice>
+        <choice>
+          <value>StructuralBrick</value>
+          <display_name>StructuralBrick</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>wall_siding_type</name>
+      <display_name>Wall: Siding Type</display_name>
+      <description>The siding type of the walls. Also applies to rim joists.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>aluminum siding</value>
+          <display_name>aluminum siding</display_name>
+        </choice>
+        <choice>
+          <value>asbestos siding</value>
+          <display_name>asbestos siding</display_name>
+        </choice>
+        <choice>
+          <value>brick veneer</value>
+          <display_name>brick veneer</display_name>
+        </choice>
+        <choice>
+          <value>composite shingle siding</value>
+          <display_name>composite shingle siding</display_name>
+        </choice>
+        <choice>
+          <value>fiber cement siding</value>
+          <display_name>fiber cement siding</display_name>
+        </choice>
+        <choice>
+          <value>masonite siding</value>
+          <display_name>masonite siding</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>stucco</value>
+          <display_name>stucco</display_name>
+        </choice>
+        <choice>
+          <value>synthetic stucco</value>
+          <display_name>synthetic stucco</display_name>
+        </choice>
+        <choice>
+          <value>vinyl siding</value>
+          <display_name>vinyl siding</display_name>
+        </choice>
+        <choice>
+          <value>wood siding</value>
+          <display_name>wood siding</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>wall_color</name>
+      <display_name>Wall: Color</display_name>
+      <description>The color of the walls. Also applies to rim joists.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>medium</default_value>
+      <choices>
+        <choice>
+          <value>dark</value>
+          <display_name>dark</display_name>
+        </choice>
+        <choice>
+          <value>light</value>
+          <display_name>light</display_name>
+        </choice>
+        <choice>
+          <value>medium</value>
+          <display_name>medium</display_name>
+        </choice>
+        <choice>
+          <value>medium dark</value>
+          <display_name>medium dark</display_name>
+        </choice>
+        <choice>
+          <value>reflective</value>
+          <display_name>reflective</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>wall_assembly_r</name>
+      <display_name>Wall: Assembly R-value</display_name>
+      <description>Assembly R-value of the walls.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>11.9</default_value>
+    </argument>
+    <argument>
+      <name>window_front_wwr</name>
+      <display_name>Windows: Front Window-to-Wall Ratio</display_name>
+      <description>The ratio of window area to wall area for the unit's front facade. Enter 0 if specifying Front Window Area instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.18</default_value>
+    </argument>
+    <argument>
+      <name>window_back_wwr</name>
+      <display_name>Windows: Back Window-to-Wall Ratio</display_name>
+      <description>The ratio of window area to wall area for the unit's back facade. Enter 0 if specifying Back Window Area instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.18</default_value>
+    </argument>
+    <argument>
+      <name>window_left_wwr</name>
+      <display_name>Windows: Left Window-to-Wall Ratio</display_name>
+      <description>The ratio of window area to wall area for the unit's left facade (when viewed from the front). Enter 0 if specifying Left Window Area instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.18</default_value>
+    </argument>
+    <argument>
+      <name>window_right_wwr</name>
+      <display_name>Windows: Right Window-to-Wall Ratio</display_name>
+      <description>The ratio of window area to wall area for the unit's right facade (when viewed from the front). Enter 0 if specifying Right Window Area instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.18</default_value>
+    </argument>
+    <argument>
+      <name>window_area_front</name>
+      <display_name>Windows: Front Window Area</display_name>
+      <description>The amount of window area on the unit's front facade. Enter 0 if specifying Front Window-to-Wall Ratio instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>window_area_back</name>
+      <display_name>Windows: Back Window Area</display_name>
+      <description>The amount of window area on the unit's back facade. Enter 0 if specifying Back Window-to-Wall Ratio instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>window_area_left</name>
+      <display_name>Windows: Left Window Area</display_name>
+      <description>The amount of window area on the unit's left facade (when viewed from the front). Enter 0 if specifying Left Window-to-Wall Ratio instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>window_area_right</name>
+      <display_name>Windows: Right Window Area</display_name>
+      <description>The amount of window area on the unit's right facade (when viewed from the front). Enter 0 if specifying Right Window-to-Wall Ratio instead.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>window_aspect_ratio</name>
+      <display_name>Windows: Aspect Ratio</display_name>
+      <description>Ratio of window height to width.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1.333</default_value>
+    </argument>
+    <argument>
+      <name>window_fraction_operable</name>
+      <display_name>Windows: Fraction Operable</display_name>
+      <description>Fraction of windows that are operable.</description>
+      <type>Double</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>window_ufactor</name>
+      <display_name>Windows: U-Factor</display_name>
+      <description>Full-assembly NFRC U-factor.</description>
+      <type>Double</type>
+      <units>Btu/hr-ft^2-R</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.37</default_value>
+    </argument>
+    <argument>
+      <name>window_shgc</name>
+      <display_name>Windows: SHGC</display_name>
+      <description>Full-assembly NFRC solar heat gain coefficient.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.3</default_value>
+    </argument>
+    <argument>
+      <name>window_interior_shading_winter</name>
+      <display_name>Windows: Winter Interior Shading</display_name>
+      <description>Interior shading multiplier for the heating season. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc.</description>
+      <type>Double</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>window_interior_shading_summer</name>
+      <display_name>Windows: Summer Interior Shading</display_name>
+      <description>Interior shading multiplier for the cooling season. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc.</description>
+      <type>Double</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>window_exterior_shading_winter</name>
+      <display_name>Windows: Winter Exterior Shading</display_name>
+      <description>Exterior shading multiplier for the heating season. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc.</description>
+      <type>Double</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>window_exterior_shading_summer</name>
+      <display_name>Windows: Summer Exterior Shading</display_name>
+      <description>Exterior shading multiplier for the cooling season. 1.0 indicates no reduction in solar gain, 0.85 indicates 15% reduction, etc.</description>
+      <type>Double</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>overhangs_front_depth</name>
+      <display_name>Overhangs: Front Depth</display_name>
+      <description>The depth of overhangs for windows for the front facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_front_distance_to_top_of_window</name>
+      <display_name>Overhangs: Front Distance to Top of Window</display_name>
+      <description>The overhangs distance to the top of window for the front facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_front_distance_to_bottom_of_window</name>
+      <display_name>Overhangs: Front Distance to Bottom of Window</display_name>
+      <description>The overhangs distance to the bottom of window for the front facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>4</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_back_depth</name>
+      <display_name>Overhangs: Back Depth</display_name>
+      <description>The depth of overhangs for windows for the back facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_back_distance_to_top_of_window</name>
+      <display_name>Overhangs: Back Distance to Top of Window</display_name>
+      <description>The overhangs distance to the top of window for the back facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_back_distance_to_bottom_of_window</name>
+      <display_name>Overhangs: Back Distance to Bottom of Window</display_name>
+      <description>The overhangs distance to the bottom of window for the back facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>4</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_left_depth</name>
+      <display_name>Overhangs: Left Depth</display_name>
+      <description>The depth of overhangs for windows for the left facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_left_distance_to_top_of_window</name>
+      <display_name>Overhangs: Left Distance to Top of Window</display_name>
+      <description>The overhangs distance to the top of window for the left facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_left_distance_to_bottom_of_window</name>
+      <display_name>Overhangs: Left Distance to Bottom of Window</display_name>
+      <description>The overhangs distance to the bottom of window for the left facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>4</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_right_depth</name>
+      <display_name>Overhangs: Right Depth</display_name>
+      <description>The depth of overhangs for windows for the right facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_right_distance_to_top_of_window</name>
+      <display_name>Overhangs: Right Distance to Top of Window</display_name>
+      <description>The overhangs distance to the top of window for the right facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>overhangs_right_distance_to_bottom_of_window</name>
+      <display_name>Overhangs: Right Distance to Bottom of Window</display_name>
+      <description>The overhangs distance to the bottom of window for the right facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>4</default_value>
+    </argument>
+    <argument>
+      <name>skylight_area_front</name>
+      <display_name>Skylights: Front Roof Area</display_name>
+      <description>The amount of skylight area on the unit's front conditioned roof facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>skylight_area_back</name>
+      <display_name>Skylights: Back Roof Area</display_name>
+      <description>The amount of skylight area on the unit's back conditioned roof facade.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>skylight_area_left</name>
+      <display_name>Skylights: Left Roof Area</display_name>
+      <description>The amount of skylight area on the unit's left conditioned roof facade (when viewed from the front).</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>skylight_area_right</name>
+      <display_name>Skylights: Right Roof Area</display_name>
+      <description>The amount of skylight area on the unit's right conditioned roof facade (when viewed from the front).</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>skylight_ufactor</name>
+      <display_name>Skylights: U-Factor</display_name>
+      <description>Full-assembly NFRC U-factor.</description>
+      <type>Double</type>
+      <units>Btu/hr-ft^2-R</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.33</default_value>
+    </argument>
+    <argument>
+      <name>skylight_shgc</name>
+      <display_name>Skylights: SHGC</display_name>
+      <description>Full-assembly NFRC solar heat gain coefficient.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.45</default_value>
+    </argument>
+    <argument>
+      <name>door_area</name>
+      <display_name>Doors: Area</display_name>
+      <description>The area of the opaque door(s).</description>
+      <type>Double</type>
+      <units>ft^2</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>20</default_value>
+    </argument>
+    <argument>
+      <name>door_rvalue</name>
+      <display_name>Doors: R-value</display_name>
+      <description>R-value of the opaque door(s).</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>4.4</default_value>
+    </argument>
+    <argument>
+      <name>air_leakage_units</name>
+      <display_name>Air Leakage: Units</display_name>
+      <description>The unit of measure for the air leakage.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>ACH</default_value>
+      <choices>
+        <choice>
+          <value>ACH</value>
+          <display_name>ACH</display_name>
+        </choice>
+        <choice>
+          <value>CFM</value>
+          <display_name>CFM</display_name>
+        </choice>
+        <choice>
+          <value>ACHnatural</value>
+          <display_name>ACHnatural</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>air_leakage_house_pressure</name>
+      <display_name>Air Leakage: House Pressure</display_name>
+      <description>The house pressure relative to outside. Required when units are ACH or CFM.</description>
+      <type>Double</type>
+      <units>Pa</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>50</default_value>
+    </argument>
+    <argument>
+      <name>air_leakage_value</name>
+      <display_name>Air Leakage: Value</display_name>
+      <description>Air exchange rate value.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>3</default_value>
+    </argument>
+    <argument>
+      <name>heating_system_type</name>
+      <display_name>Heating System: Type</display_name>
+      <description>The type of heating system. Use 'none' if there is no heating system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>Furnace</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>Furnace</value>
+          <display_name>Furnace</display_name>
+        </choice>
+        <choice>
+          <value>WallFurnace</value>
+          <display_name>WallFurnace</display_name>
+        </choice>
+        <choice>
+          <value>FloorFurnace</value>
+          <display_name>FloorFurnace</display_name>
+        </choice>
+        <choice>
+          <value>Boiler</value>
+          <display_name>Boiler</display_name>
+        </choice>
+        <choice>
+          <value>ElectricResistance</value>
+          <display_name>ElectricResistance</display_name>
+        </choice>
+        <choice>
+          <value>Stove</value>
+          <display_name>Stove</display_name>
+        </choice>
+        <choice>
+          <value>PortableHeater</value>
+          <display_name>PortableHeater</display_name>
+        </choice>
+        <choice>
+          <value>Fireplace</value>
+          <display_name>Fireplace</display_name>
+        </choice>
+        <choice>
+          <value>FixedHeater</value>
+          <display_name>FixedHeater</display_name>
+        </choice>
+        <choice>
+          <value>PackagedTerminalAirConditionerHeating</value>
+          <display_name>PackagedTerminalAirConditionerHeating</display_name>
+        </choice>
+        <choice>
+          <value>Shared Boiler w/ Baseboard</value>
+          <display_name>Shared Boiler w/ Baseboard</display_name>
+        </choice>
+        <choice>
+          <value>Shared Boiler w/ Ductless Fan Coil</value>
+          <display_name>Shared Boiler w/ Ductless Fan Coil</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heating_system_fuel</name>
+      <display_name>Heating System: Fuel Type</display_name>
+      <description>The fuel type of the heating system. Ignored for ElectricResistance and PackagedTerminalAirConditionerHeating.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>natural gas</default_value>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>wood pellets</value>
+          <display_name>wood pellets</display_name>
+        </choice>
+        <choice>
+          <value>coal</value>
+          <display_name>coal</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heating_system_heating_efficiency</name>
+      <display_name>Heating System: Rated AFUE or Percent</display_name>
+      <description>The rated heating efficiency value of the heating system.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.78</default_value>
+    </argument>
+    <argument>
+      <name>heating_system_heating_capacity</name>
+      <display_name>Heating System: Heating Capacity</display_name>
+      <description>The output heating capacity of the heating system. Enter 'auto' to size the capacity based on ACCA Manual J/S.</description>
+      <type>String</type>
+      <units>Btu/hr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>heating_system_fraction_heat_load_served</name>
+      <display_name>Heating System: Fraction Heat Load Served</display_name>
+      <description>The heating load served by the heating system.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>heating_system_airflow_defect_ratio</name>
+      <display_name>Heating System: Airflow Defect Ratio</display_name>
+      <description>The airflow defect ratio, defined as (InstalledAirflow - DesignAirflow) / DesignAirflow, of the heating system per ANSI/RESNET/ACCA Standard 310. A value of zero means no airflow defect. Applies only to Furnace.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>cooling_system_type</name>
+      <display_name>Cooling System: Type</display_name>
+      <description>The type of cooling system. Use 'none' if there is no cooling system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>central air conditioner</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>central air conditioner</value>
+          <display_name>central air conditioner</display_name>
+        </choice>
+        <choice>
+          <value>room air conditioner</value>
+          <display_name>room air conditioner</display_name>
+        </choice>
+        <choice>
+          <value>evaporative cooler</value>
+          <display_name>evaporative cooler</display_name>
+        </choice>
+        <choice>
+          <value>mini-split</value>
+          <display_name>mini-split</display_name>
+        </choice>
+        <choice>
+          <value>packaged terminal air conditioner</value>
+          <display_name>packaged terminal air conditioner</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooling_system_cooling_efficiency_type</name>
+      <display_name>Cooling System: Efficiency Type</display_name>
+      <description>The efficiency type of the cooling system. System types central air conditioner and mini-split use SEER. System types room air conditioner and packaged terminal air conditioner use EER or CEER. Ignored for system type evaporative cooler.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>SEER</default_value>
+      <choices>
+        <choice>
+          <value>SEER</value>
+          <display_name>SEER</display_name>
+        </choice>
+        <choice>
+          <value>EER</value>
+          <display_name>EER</display_name>
+        </choice>
+        <choice>
+          <value>CEER</value>
+          <display_name>CEER</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooling_system_cooling_efficiency</name>
+      <display_name>Cooling System: Efficiency</display_name>
+      <description>The rated efficiency value of the cooling system. Ignored for evaporative cooler.</description>
+      <type>Double</type>
+      <units>SEER or EER or CEER</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>13</default_value>
+    </argument>
+    <argument>
+      <name>cooling_system_cooling_compressor_type</name>
+      <display_name>Cooling System: Cooling Compressor Type</display_name>
+      <description>The compressor type of the cooling system. Only applies to central air conditioner.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>single stage</value>
+          <display_name>single stage</display_name>
+        </choice>
+        <choice>
+          <value>two stage</value>
+          <display_name>two stage</display_name>
+        </choice>
+        <choice>
+          <value>variable speed</value>
+          <display_name>variable speed</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooling_system_cooling_sensible_heat_fraction</name>
+      <display_name>Cooling System: Cooling Sensible Heat Fraction</display_name>
+      <description>The sensible heat fraction of the cooling system. Ignored for evaporative cooler.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>cooling_system_cooling_capacity</name>
+      <display_name>Cooling System: Cooling Capacity</display_name>
+      <description>The output cooling capacity of the cooling system. Enter 'auto' to size the capacity based on ACCA Manual J/S.</description>
+      <type>String</type>
+      <units>tons</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>cooling_system_fraction_cool_load_served</name>
+      <display_name>Cooling System: Fraction Cool Load Served</display_name>
+      <description>The cooling load served by the cooling system.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>cooling_system_is_ducted</name>
+      <display_name>Cooling System: Is Ducted</display_name>
+      <description>Whether the cooling system is ducted or not. Only used for mini-split and evaporative cooler. It's assumed that central air conditioner is ducted, and room air conditioner and packaged terminal air conditioner are not ducted.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooling_system_airflow_defect_ratio</name>
+      <display_name>Cooling System: Airflow Defect Ratio</display_name>
+      <description>The airflow defect ratio, defined as (InstalledAirflow - DesignAirflow) / DesignAirflow, of the cooling system per ANSI/RESNET/ACCA Standard 310. A value of zero means no airflow defect. Applies only to central air conditioner and ducted mini-split.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>cooling_system_charge_defect_ratio</name>
+      <display_name>Cooling System: Charge Defect Ratio</display_name>
+      <description>The refrigerant charge defect ratio, defined as (InstalledCharge - DesignCharge) / DesignCharge, of the cooling system per ANSI/RESNET/ACCA Standard 310. A value of zero means no refrigerant charge defect. Applies only to central air conditioner and mini-split.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>heat_pump_type</name>
+      <display_name>Heat Pump: Type</display_name>
+      <description>The type of heat pump. Use 'none' if there is no heat pump.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>air-to-air</value>
+          <display_name>air-to-air</display_name>
+        </choice>
+        <choice>
+          <value>mini-split</value>
+          <display_name>mini-split</display_name>
+        </choice>
+        <choice>
+          <value>ground-to-air</value>
+          <display_name>ground-to-air</display_name>
+        </choice>
+        <choice>
+          <value>packaged terminal heat pump</value>
+          <display_name>packaged terminal heat pump</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heat_pump_heating_efficiency_type</name>
+      <display_name>Heat Pump: Heating Efficiency Type</display_name>
+      <description>The heating efficiency type of heat pump. System types air-to-air and mini-split use HSPF. System types ground-to-air and packaged terminal heat pump use COP.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>HSPF</default_value>
+      <choices>
+        <choice>
+          <value>HSPF</value>
+          <display_name>HSPF</display_name>
+        </choice>
+        <choice>
+          <value>COP</value>
+          <display_name>COP</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heat_pump_heating_efficiency</name>
+      <display_name>Heat Pump: Heating Efficiency</display_name>
+      <description>The rated heating efficiency value of the heat pump.</description>
+      <type>Double</type>
+      <units>HSPF or COP</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>7.7</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_cooling_efficiency_type</name>
+      <display_name>Heat Pump: Cooling Efficiency Type</display_name>
+      <description>The cooling efficiency type of heat pump. System types air-to-air and mini-split use SEER. System types ground-to-air and packaged terminal heat pump use EER.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>SEER</default_value>
+      <choices>
+        <choice>
+          <value>SEER</value>
+          <display_name>SEER</display_name>
+        </choice>
+        <choice>
+          <value>EER</value>
+          <display_name>EER</display_name>
+        </choice>
+        <choice>
+          <value>CEER</value>
+          <display_name>CEER</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heat_pump_cooling_efficiency</name>
+      <display_name>Heat Pump: Cooling Efficiency</display_name>
+      <description>The rated cooling efficiency value of the heat pump.</description>
+      <type>Double</type>
+      <units>SEER or EER</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>13</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_cooling_compressor_type</name>
+      <display_name>Heat Pump: Cooling Compressor Type</display_name>
+      <description>The compressor type of the heat pump. Only applies to air-to-air.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>single stage</value>
+          <display_name>single stage</display_name>
+        </choice>
+        <choice>
+          <value>two stage</value>
+          <display_name>two stage</display_name>
+        </choice>
+        <choice>
+          <value>variable speed</value>
+          <display_name>variable speed</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heat_pump_cooling_sensible_heat_fraction</name>
+      <display_name>Heat Pump: Cooling Sensible Heat Fraction</display_name>
+      <description>The sensible heat fraction of the heat pump.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>heat_pump_heating_capacity</name>
+      <display_name>Heat Pump: Heating Capacity</display_name>
+      <description>The output heating capacity of the heat pump. Enter 'auto' to size the capacity based on ACCA Manual J/S (i.e., based on cooling design loads with some oversizing allowances for heating design loads). Enter 'auto using max load' to size the capacity based on the maximum of heating/cooling design loads.</description>
+      <type>String</type>
+      <units>Btu/hr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_heating_capacity_17_f</name>
+      <display_name>Heat Pump: Heating Capacity 17F</display_name>
+      <description>The output heating capacity of the heat pump at 17F. Only applies to air-to-air and mini-split.</description>
+      <type>String</type>
+      <units>Btu/hr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_cooling_capacity</name>
+      <display_name>Heat Pump: Cooling Capacity</display_name>
+      <description>The output cooling capacity of the heat pump. Enter 'auto' to size the capacity based on ACCA Manual J/S.</description>
+      <type>String</type>
+      <units>Btu/hr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_fraction_heat_load_served</name>
+      <display_name>Heat Pump: Fraction Heat Load Served</display_name>
+      <description>The heating load served by the heat pump.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_fraction_cool_load_served</name>
+      <display_name>Heat Pump: Fraction Cool Load Served</display_name>
+      <description>The cooling load served by the heat pump.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_backup_type</name>
+      <display_name>Heat Pump: Backup Type</display_name>
+      <description>The backup type of the heat pump. If 'integrated', represents e.g. built-in electric strip heat or dual-fuel integrated furnace. If 'separate', represents e.g. electric baseboard or boiler based on the Heating System 2 specified below. Use 'none' if there is no backup heating.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>integrated</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>integrated</value>
+          <display_name>integrated</display_name>
+        </choice>
+        <choice>
+          <value>separate</value>
+          <display_name>separate</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heat_pump_backup_fuel</name>
+      <display_name>Heat Pump: Backup Fuel Type</display_name>
+      <description>The backup fuel type of the heat pump. Only applies if Backup Type is 'integrated'.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>electricity</default_value>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heat_pump_backup_heating_efficiency</name>
+      <display_name>Heat Pump: Backup Rated Efficiency</display_name>
+      <description>The backup rated efficiency value of the heat pump. Percent for electricity fuel type. AFUE otherwise. Only applies if Backup Type is 'integrated'.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_backup_heating_capacity</name>
+      <display_name>Heat Pump: Backup Heating Capacity</display_name>
+      <description>The backup output heating capacity of the heat pump. Enter 'auto' to size the capacity based on ACCA Manual J/S. Only applies if Backup Type is 'integrated'.</description>
+      <type>String</type>
+      <units>Btu/hr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>heat_pump_backup_heating_switchover_temp</name>
+      <display_name>Heat Pump: Backup Heating Switchover Temperature</display_name>
+      <description>The temperature at which the heat pump stops operating and the backup heating system starts running. Only applies to air-to-air and mini-split. If not provided, backup heating will operate as needed when heat pump capacity is insufficient. Applies if Backup Type is either 'integrated' or 'separate'.</description>
+      <type>Double</type>
+      <units>deg-F</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>heat_pump_is_ducted</name>
+      <display_name>Heat Pump: Is Ducted</display_name>
+      <description>Whether the heat pump is ducted or not. Only used for mini-split. It's assumed that air-to-air and ground-to-air are ducted.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heat_pump_airflow_defect_ratio</name>
+      <display_name>Heat Pump: Airflow Defect Ratio</display_name>
+      <description>The airflow defect ratio, defined as (InstalledAirflow - DesignAirflow) / DesignAirflow, of the heat pump per ANSI/RESNET/ACCA Standard 310. A value of zero means no airflow defect. Applies only to air-to-air, ducted mini-split, and ground-to-air.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>heat_pump_charge_defect_ratio</name>
+      <display_name>Heat Pump: Charge Defect Ratio</display_name>
+      <description>The refrigerant charge defect ratio, defined as (InstalledCharge - DesignCharge) / DesignCharge, of the heat pump per ANSI/RESNET/ACCA Standard 310. A value of zero means no refrigerant charge defect. Applies to all heat pump types.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>heating_system_2_type</name>
+      <display_name>Heating System 2: Type</display_name>
+      <description>The type of the second heating system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>WallFurnace</value>
+          <display_name>WallFurnace</display_name>
+        </choice>
+        <choice>
+          <value>FloorFurnace</value>
+          <display_name>FloorFurnace</display_name>
+        </choice>
+        <choice>
+          <value>Boiler</value>
+          <display_name>Boiler</display_name>
+        </choice>
+        <choice>
+          <value>ElectricResistance</value>
+          <display_name>ElectricResistance</display_name>
+        </choice>
+        <choice>
+          <value>Stove</value>
+          <display_name>Stove</display_name>
+        </choice>
+        <choice>
+          <value>PortableHeater</value>
+          <display_name>PortableHeater</display_name>
+        </choice>
+        <choice>
+          <value>Fireplace</value>
+          <display_name>Fireplace</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heating_system_2_fuel</name>
+      <display_name>Heating System 2: Fuel Type</display_name>
+      <description>The fuel type of the second heating system. Ignored for ElectricResistance.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>electricity</default_value>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>wood pellets</value>
+          <display_name>wood pellets</display_name>
+        </choice>
+        <choice>
+          <value>coal</value>
+          <display_name>coal</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>heating_system_2_heating_efficiency</name>
+      <display_name>Heating System 2: Rated AFUE or Percent</display_name>
+      <description>The rated heating efficiency value of the second heating system.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>heating_system_2_heating_capacity</name>
+      <display_name>Heating System 2: Heating Capacity</display_name>
+      <description>The output heating capacity of the second heating system. Enter 'auto' to size the capacity based on ACCA Manual J/S.</description>
+      <type>String</type>
+      <units>Btu/hr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>heating_system_2_fraction_heat_load_served</name>
+      <display_name>Heating System 2: Fraction Heat Load Served</display_name>
+      <description>The heat load served fraction of the second heating system. Ignored if this heating system serves as a backup system for a heat pump.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.25</default_value>
+    </argument>
+    <argument>
+      <name>hvac_control_type</name>
+      <display_name>HVAC Control: Type</display_name>
+      <description>The type of thermostat.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>manual thermostat</default_value>
+      <choices>
+        <choice>
+          <value>manual thermostat</value>
+          <display_name>manual thermostat</display_name>
+        </choice>
+        <choice>
+          <value>programmable thermostat</value>
+          <display_name>programmable thermostat</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>hvac_control_heating_weekday_setpoint</name>
+      <display_name>HVAC Control: Heating Weekday Setpoint Schedule</display_name>
+      <description>Specify the constant or 24-hour comma-separated weekday heating setpoint schedule.</description>
+      <type>String</type>
+      <units>deg-F</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>71</default_value>
+    </argument>
+    <argument>
+      <name>hvac_control_heating_weekend_setpoint</name>
+      <display_name>HVAC Control: Heating Weekend Setpoint Schedule</display_name>
+      <description>Specify the constant or 24-hour comma-separated weekend heating setpoint schedule.</description>
+      <type>String</type>
+      <units>deg-F</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>71</default_value>
+    </argument>
+    <argument>
+      <name>hvac_control_cooling_weekday_setpoint</name>
+      <display_name>HVAC Control: Cooling Weekday Setpoint Schedule</display_name>
+      <description>Specify the constant or 24-hour comma-separated weekday cooling setpoint schedule.</description>
+      <type>String</type>
+      <units>deg-F</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>76</default_value>
+    </argument>
+    <argument>
+      <name>hvac_control_cooling_weekend_setpoint</name>
+      <display_name>HVAC Control: Cooling Weekend Setpoint Schedule</display_name>
+      <description>Specify the constant or 24-hour comma-separated weekend cooling setpoint schedule.</description>
+      <type>String</type>
+      <units>deg-F</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>76</default_value>
+    </argument>
+    <argument>
+      <name>hvac_control_heating_season_period</name>
+      <display_name>HVAC Control: Heating Season Period</display_name>
+      <description>Enter a date like "Nov 1 - Jun 30".</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>hvac_control_cooling_season_period</name>
+      <display_name>HVAC Control: Cooling Season Period</display_name>
+      <description>Enter a date like "Jun 1 - Oct 31".</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>ducts_leakage_units</name>
+      <display_name>Ducts: Leakage Units</display_name>
+      <description>The leakage units of the ducts.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>Percent</default_value>
+      <choices>
+        <choice>
+          <value>CFM25</value>
+          <display_name>CFM25</display_name>
+        </choice>
+        <choice>
+          <value>CFM50</value>
+          <display_name>CFM50</display_name>
+        </choice>
+        <choice>
+          <value>Percent</value>
+          <display_name>Percent</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>ducts_supply_leakage_to_outside_value</name>
+      <display_name>Ducts: Supply Leakage to Outside Value</display_name>
+      <description>The leakage value to outside for the supply ducts.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.1</default_value>
+    </argument>
+    <argument>
+      <name>ducts_return_leakage_to_outside_value</name>
+      <display_name>Ducts: Return Leakage to Outside Value</display_name>
+      <description>The leakage value to outside for the return ducts.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.1</default_value>
+    </argument>
+    <argument>
+      <name>ducts_supply_location</name>
+      <display_name>Ducts: Supply Location</display_name>
+      <description>The location of the supply ducts.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - vented</value>
+          <display_name>crawlspace - vented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - unvented</value>
+          <display_name>crawlspace - unvented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - conditioned</value>
+          <display_name>crawlspace - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>attic - vented</value>
+          <display_name>attic - vented</display_name>
+        </choice>
+        <choice>
+          <value>attic - unvented</value>
+          <display_name>attic - unvented</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>exterior wall</value>
+          <display_name>exterior wall</display_name>
+        </choice>
+        <choice>
+          <value>under slab</value>
+          <display_name>under slab</display_name>
+        </choice>
+        <choice>
+          <value>roof deck</value>
+          <display_name>roof deck</display_name>
+        </choice>
+        <choice>
+          <value>outside</value>
+          <display_name>outside</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>ducts_supply_insulation_r</name>
+      <display_name>Ducts: Supply Insulation R-Value</display_name>
+      <description>The insulation r-value of the supply ducts excluding air films.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>ducts_supply_surface_area</name>
+      <display_name>Ducts: Supply Surface Area</display_name>
+      <description>The surface area of the supply ducts.</description>
+      <type>String</type>
+      <units>ft^2</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>ducts_return_location</name>
+      <display_name>Ducts: Return Location</display_name>
+      <description>The location of the return ducts.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - vented</value>
+          <display_name>crawlspace - vented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - unvented</value>
+          <display_name>crawlspace - unvented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - conditioned</value>
+          <display_name>crawlspace - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>attic - vented</value>
+          <display_name>attic - vented</display_name>
+        </choice>
+        <choice>
+          <value>attic - unvented</value>
+          <display_name>attic - unvented</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>exterior wall</value>
+          <display_name>exterior wall</display_name>
+        </choice>
+        <choice>
+          <value>under slab</value>
+          <display_name>under slab</display_name>
+        </choice>
+        <choice>
+          <value>roof deck</value>
+          <display_name>roof deck</display_name>
+        </choice>
+        <choice>
+          <value>outside</value>
+          <display_name>outside</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>ducts_return_insulation_r</name>
+      <display_name>Ducts: Return Insulation R-Value</display_name>
+      <description>The insulation r-value of the return ducts excluding air films.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>ducts_return_surface_area</name>
+      <display_name>Ducts: Return Surface Area</display_name>
+      <description>The surface area of the return ducts.</description>
+      <type>String</type>
+      <units>ft^2</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>ducts_number_of_return_registers</name>
+      <display_name>Ducts: Number of Return Registers</display_name>
+      <description>The number of return registers of the ducts. Ignored for ducted evaporative cooler.</description>
+      <type>String</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_fan_type</name>
+      <display_name>Mechanical Ventilation: Fan Type</display_name>
+      <description>The type of the mechanical ventilation. Use 'none' if there is no mechanical ventilation system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>exhaust only</value>
+          <display_name>exhaust only</display_name>
+        </choice>
+        <choice>
+          <value>supply only</value>
+          <display_name>supply only</display_name>
+        </choice>
+        <choice>
+          <value>energy recovery ventilator</value>
+          <display_name>energy recovery ventilator</display_name>
+        </choice>
+        <choice>
+          <value>heat recovery ventilator</value>
+          <display_name>heat recovery ventilator</display_name>
+        </choice>
+        <choice>
+          <value>balanced</value>
+          <display_name>balanced</display_name>
+        </choice>
+        <choice>
+          <value>central fan integrated supply</value>
+          <display_name>central fan integrated supply</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>mech_vent_flow_rate</name>
+      <display_name>Mechanical Ventilation: Flow Rate</display_name>
+      <description>The flow rate of the mechanical ventilation.</description>
+      <type>String</type>
+      <units>CFM</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_hours_in_operation</name>
+      <display_name>Mechanical Ventilation: Hours In Operation</display_name>
+      <description>The hours in operation of the mechanical ventilation.</description>
+      <type>String</type>
+      <units>hrs/day</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_recovery_efficiency_type</name>
+      <display_name>Mechanical Ventilation: Total Recovery Efficiency Type</display_name>
+      <description>The total recovery efficiency type of the mechanical ventilation.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>Unadjusted</default_value>
+      <choices>
+        <choice>
+          <value>Unadjusted</value>
+          <display_name>Unadjusted</display_name>
+        </choice>
+        <choice>
+          <value>Adjusted</value>
+          <display_name>Adjusted</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>mech_vent_total_recovery_efficiency</name>
+      <display_name>Mechanical Ventilation: Total Recovery Efficiency</display_name>
+      <description>The Unadjusted or Adjusted total recovery efficiency of the mechanical ventilation. Applies to energy recovery ventilator.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.48</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_sensible_recovery_efficiency</name>
+      <display_name>Mechanical Ventilation: Sensible Recovery Efficiency</display_name>
+      <description>The Unadjusted or Adjusted sensible recovery efficiency of the mechanical ventilation. Applies to energy recovery ventilator and heat recovery ventilator.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.72</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_fan_power</name>
+      <display_name>Mechanical Ventilation: Fan Power</display_name>
+      <description>The fan power of the mechanical ventilation.</description>
+      <type>String</type>
+      <units>W</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_num_units_served</name>
+      <display_name>Mechanical Ventilation: Number of Units Served</display_name>
+      <description>Number of dwelling units served by the mechanical ventilation system. Must be 1 if single-family detached. Used to apportion flow rate and fan power to the unit.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_shared_frac_recirculation</name>
+      <display_name>Shared Mechanical Ventilation: Fraction Recirculation</display_name>
+      <description>Fraction of the total supply air that is recirculated, with the remainder assumed to be outdoor air. The value must be 0 for exhaust only systems. This is required for a shared mechanical ventilation system.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>mech_vent_shared_preheating_fuel</name>
+      <display_name>Shared Mechanical Ventilation: Preheating Fuel</display_name>
+      <description>Fuel type of the preconditioning heating equipment. Only used for a shared mechanical ventilation system.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>wood pellets</value>
+          <display_name>wood pellets</display_name>
+        </choice>
+        <choice>
+          <value>coal</value>
+          <display_name>coal</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>mech_vent_shared_preheating_efficiency</name>
+      <display_name>Shared Mechanical Ventilation: Preheating Efficiency</display_name>
+      <description>Efficiency of the preconditioning heating equipment. Only used for a shared mechanical ventilation system.</description>
+      <type>Double</type>
+      <units>COP</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>mech_vent_shared_preheating_fraction_heat_load_served</name>
+      <display_name>Shared Mechanical Ventilation: Preheating Fraction Ventilation Heat Load Served</display_name>
+      <description>Fraction of heating load introduced by the shared ventilation system that is met by the preconditioning heating equipment.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>mech_vent_shared_precooling_fuel</name>
+      <display_name>Shared Mechanical Ventilation: Precooling Fuel</display_name>
+      <description>Fuel type of the preconditioning cooling equipment. Only used for a shared mechanical ventilation system.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>mech_vent_shared_precooling_efficiency</name>
+      <display_name>Shared Mechanical Ventilation: Precooling Efficiency</display_name>
+      <description>Efficiency of the preconditioning cooling equipment. Only used for a shared mechanical ventilation system.</description>
+      <type>Double</type>
+      <units>COP</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>mech_vent_shared_precooling_fraction_cool_load_served</name>
+      <display_name>Shared Mechanical Ventilation: Precooling Fraction Ventilation Cool Load Served</display_name>
+      <description>Fraction of cooling load introduced by the shared ventilation system that is met by the preconditioning cooling equipment.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>mech_vent_2_fan_type</name>
+      <display_name>Mechanical Ventilation 2: Fan Type</display_name>
+      <description>The type of the second mechanical ventilation. Use 'none' if there is no second mechanical ventilation system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>exhaust only</value>
+          <display_name>exhaust only</display_name>
+        </choice>
+        <choice>
+          <value>supply only</value>
+          <display_name>supply only</display_name>
+        </choice>
+        <choice>
+          <value>energy recovery ventilator</value>
+          <display_name>energy recovery ventilator</display_name>
+        </choice>
+        <choice>
+          <value>heat recovery ventilator</value>
+          <display_name>heat recovery ventilator</display_name>
+        </choice>
+        <choice>
+          <value>balanced</value>
+          <display_name>balanced</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>mech_vent_2_flow_rate</name>
+      <display_name>Mechanical Ventilation 2: Flow Rate</display_name>
+      <description>The flow rate of the second mechanical ventilation.</description>
+      <type>Double</type>
+      <units>CFM</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>110</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_2_hours_in_operation</name>
+      <display_name>Mechanical Ventilation 2: Hours In Operation</display_name>
+      <description>The hours in operation of the second mechanical ventilation.</description>
+      <type>Double</type>
+      <units>hrs/day</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>24</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_2_recovery_efficiency_type</name>
+      <display_name>Mechanical Ventilation 2: Total Recovery Efficiency Type</display_name>
+      <description>The total recovery efficiency type of the second mechanical ventilation.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>Unadjusted</default_value>
+      <choices>
+        <choice>
+          <value>Unadjusted</value>
+          <display_name>Unadjusted</display_name>
+        </choice>
+        <choice>
+          <value>Adjusted</value>
+          <display_name>Adjusted</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>mech_vent_2_total_recovery_efficiency</name>
+      <display_name>Mechanical Ventilation 2: Total Recovery Efficiency</display_name>
+      <description>The Unadjusted or Adjusted total recovery efficiency of the second mechanical ventilation. Applies to energy recovery ventilator.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.48</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_2_sensible_recovery_efficiency</name>
+      <display_name>Mechanical Ventilation 2: Sensible Recovery Efficiency</display_name>
+      <description>The Unadjusted or Adjusted sensible recovery efficiency of the second mechanical ventilation. Applies to energy recovery ventilator and heat recovery ventilator.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.72</default_value>
+    </argument>
+    <argument>
+      <name>mech_vent_2_fan_power</name>
+      <display_name>Mechanical Ventilation 2: Fan Power</display_name>
+      <description>The fan power of the second mechanical ventilation.</description>
+      <type>Double</type>
+      <units>W</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>30</default_value>
+    </argument>
+    <argument>
+      <name>kitchen_fans_quantity</name>
+      <display_name>Kitchen Fans: Quantity</display_name>
+      <description>The quantity of the kitchen fans.</description>
+      <type>String</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>kitchen_fans_flow_rate</name>
+      <display_name>Kitchen Fans: Flow Rate</display_name>
+      <description>The flow rate of the kitchen fan.</description>
+      <type>String</type>
+      <units>CFM</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>kitchen_fans_hours_in_operation</name>
+      <display_name>Kitchen Fans: Hours In Operation</display_name>
+      <description>The hours in operation of the kitchen fan.</description>
+      <type>String</type>
+      <units>hrs/day</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>kitchen_fans_power</name>
+      <display_name>Kitchen Fans: Fan Power</display_name>
+      <description>The fan power of the kitchen fan.</description>
+      <type>String</type>
+      <units>W</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>kitchen_fans_start_hour</name>
+      <display_name>Kitchen Fans: Start Hour</display_name>
+      <description>The start hour of the kitchen fan.</description>
+      <type>String</type>
+      <units>hr</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>bathroom_fans_quantity</name>
+      <display_name>Bathroom Fans: Quantity</display_name>
+      <description>The quantity of the bathroom fans.</description>
+      <type>String</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>bathroom_fans_flow_rate</name>
+      <display_name>Bathroom Fans: Flow Rate</display_name>
+      <description>The flow rate of the bathroom fans.</description>
+      <type>String</type>
+      <units>CFM</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>bathroom_fans_hours_in_operation</name>
+      <display_name>Bathroom Fans: Hours In Operation</display_name>
+      <description>The hours in operation of the bathroom fans.</description>
+      <type>String</type>
+      <units>hrs/day</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>bathroom_fans_power</name>
+      <display_name>Bathroom Fans: Fan Power</display_name>
+      <description>The fan power of the bathroom fans.</description>
+      <type>String</type>
+      <units>W</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>bathroom_fans_start_hour</name>
+      <display_name>Bathroom Fans: Start Hour</display_name>
+      <description>The start hour of the bathroom fans.</description>
+      <type>String</type>
+      <units>hr</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>whole_house_fan_present</name>
+      <display_name>Whole House Fan: Present</display_name>
+      <description>Whether there is a whole house fan.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>whole_house_fan_flow_rate</name>
+      <display_name>Whole House Fan: Flow Rate</display_name>
+      <description>The flow rate of the whole house fan.</description>
+      <type>String</type>
+      <units>CFM</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>whole_house_fan_power</name>
+      <display_name>Whole House Fan: Fan Power</display_name>
+      <description>The fan power of the whole house fan.</description>
+      <type>String</type>
+      <units>W</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>water_heater_type</name>
+      <display_name>Water Heater: Type</display_name>
+      <description>The type of water heater. Use 'none' if there is no water heater.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>storage water heater</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>storage water heater</value>
+          <display_name>storage water heater</display_name>
+        </choice>
+        <choice>
+          <value>instantaneous water heater</value>
+          <display_name>instantaneous water heater</display_name>
+        </choice>
+        <choice>
+          <value>heat pump water heater</value>
+          <display_name>heat pump water heater</display_name>
+        </choice>
+        <choice>
+          <value>space-heating boiler with storage tank</value>
+          <display_name>space-heating boiler with storage tank</display_name>
+        </choice>
+        <choice>
+          <value>space-heating boiler with tankless coil</value>
+          <display_name>space-heating boiler with tankless coil</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>water_heater_fuel_type</name>
+      <display_name>Water Heater: Fuel Type</display_name>
+      <description>The fuel type of water heater. Ignored for heat pump water heater.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>natural gas</default_value>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>coal</value>
+          <display_name>coal</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>water_heater_location</name>
+      <display_name>Water Heater: Location</display_name>
+      <description>The location of water heater.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>attic - vented</value>
+          <display_name>attic - vented</display_name>
+        </choice>
+        <choice>
+          <value>attic - unvented</value>
+          <display_name>attic - unvented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - vented</value>
+          <display_name>crawlspace - vented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - unvented</value>
+          <display_name>crawlspace - unvented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - conditioned</value>
+          <display_name>crawlspace - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>other exterior</value>
+          <display_name>other exterior</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>water_heater_tank_volume</name>
+      <display_name>Water Heater: Tank Volume</display_name>
+      <description>Nominal volume of water heater tank. Set to 'auto' to have volume autosized. Only applies to storage water heater, heat pump water heater, and space-heating boiler with storage tank.</description>
+      <type>String</type>
+      <units>gal</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>water_heater_efficiency_type</name>
+      <display_name>Water Heater: Efficiency Type</display_name>
+      <description>The efficiency type of water heater. Does not apply to space-heating boilers.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>EnergyFactor</default_value>
+      <choices>
+        <choice>
+          <value>EnergyFactor</value>
+          <display_name>EnergyFactor</display_name>
+        </choice>
+        <choice>
+          <value>UniformEnergyFactor</value>
+          <display_name>UniformEnergyFactor</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>water_heater_efficiency</name>
+      <display_name>Water Heater: Efficiency</display_name>
+      <description>Rated Energy Factor or Uniform Energy Factor. Does not apply to space-heating boilers.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.67</default_value>
+    </argument>
+    <argument>
+      <name>water_heater_usage_bin</name>
+      <display_name>Water Heater: Usage Bin</display_name>
+      <description>The usage of the water heater. Required if Efficiency Type is UniformEnergyFactor and Type is not instantaneous water heater. Does not apply to space-heating boilers.</description>
+      <type>Choice</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>very small</value>
+          <display_name>very small</display_name>
+        </choice>
+        <choice>
+          <value>low</value>
+          <display_name>low</display_name>
+        </choice>
+        <choice>
+          <value>medium</value>
+          <display_name>medium</display_name>
+        </choice>
+        <choice>
+          <value>high</value>
+          <display_name>high</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>water_heater_recovery_efficiency</name>
+      <display_name>Water Heater: Recovery Efficiency</display_name>
+      <description>Ratio of energy delivered to water heater to the energy content of the fuel consumed by the water heater. Only used for non-electric storage water heaters.</description>
+      <type>String</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>water_heater_heating_capacity</name>
+      <display_name>Water Heater: Heating Capacity</display_name>
+      <description>Heating capacity. Set to 'auto' to have heating capacity defaulted. Only applies to storage water heater.</description>
+      <type>String</type>
+      <units>Btu/hr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>water_heater_standby_loss</name>
+      <display_name>Water Heater: Standby Loss</display_name>
+      <description>The standby loss of water heater. Only applies to space-heating boilers.</description>
+      <type>Double</type>
+      <units>deg-F/hr</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>water_heater_jacket_rvalue</name>
+      <display_name>Water Heater: Jacket R-value</display_name>
+      <description>The jacket R-value of water heater. Doesn't apply to instantaneous water heater or space-heating boiler with tankless coil.</description>
+      <type>Double</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>water_heater_setpoint_temperature</name>
+      <display_name>Water Heater: Setpoint Temperature</display_name>
+      <description>The setpoint temperature of water heater.</description>
+      <type>String</type>
+      <units>deg-F</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>water_heater_num_units_served</name>
+      <display_name>Water Heater: Number of Units Served</display_name>
+      <description>Number of dwelling units served (directly or indirectly) by the water heater. Must be 1 if single-family detached. Used to apportion water heater tank losses to the unit.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>water_heater_uses_desuperheater</name>
+      <display_name>Water Heater: Uses Desuperheater</display_name>
+      <description>Requires that the dwelling unit has a air-to-air, mini-split, or ground-to-air heat pump or a central air conditioner or mini-split air conditioner.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>hot_water_distribution_system_type</name>
+      <display_name>Hot Water Distribution: System Type</display_name>
+      <description>The type of the hot water distribution system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>Standard</default_value>
+      <choices>
+        <choice>
+          <value>Standard</value>
+          <display_name>Standard</display_name>
+        </choice>
+        <choice>
+          <value>Recirculation</value>
+          <display_name>Recirculation</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>hot_water_distribution_standard_piping_length</name>
+      <display_name>Hot Water Distribution: Standard Piping Length</display_name>
+      <description>If the distribution system is Standard, the length of the piping. A value of 'auto' will use a default.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>hot_water_distribution_recirc_control_type</name>
+      <display_name>Hot Water Distribution: Recirculation Control Type</display_name>
+      <description>If the distribution system is Recirculation, the type of hot water recirculation control, if any.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>no control</default_value>
+      <choices>
+        <choice>
+          <value>no control</value>
+          <display_name>no control</display_name>
+        </choice>
+        <choice>
+          <value>timer</value>
+          <display_name>timer</display_name>
+        </choice>
+        <choice>
+          <value>temperature</value>
+          <display_name>temperature</display_name>
+        </choice>
+        <choice>
+          <value>presence sensor demand control</value>
+          <display_name>presence sensor demand control</display_name>
+        </choice>
+        <choice>
+          <value>manual demand control</value>
+          <display_name>manual demand control</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>hot_water_distribution_recirc_piping_length</name>
+      <display_name>Hot Water Distribution: Recirculation Piping Length</display_name>
+      <description>If the distribution system is Recirculation, the length of the recirculation piping.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>hot_water_distribution_recirc_branch_piping_length</name>
+      <display_name>Hot Water Distribution: Recirculation Branch Piping Length</display_name>
+      <description>If the distribution system is Recirculation, the length of the recirculation branch piping.</description>
+      <type>String</type>
+      <units>ft</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>hot_water_distribution_recirc_pump_power</name>
+      <display_name>Hot Water Distribution: Recirculation Pump Power</display_name>
+      <description>If the distribution system is Recirculation, the recirculation pump power.</description>
+      <type>String</type>
+      <units>W</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>hot_water_distribution_pipe_r</name>
+      <display_name>Hot Water Distribution: Pipe Insulation Nominal R-Value</display_name>
+      <description>Nominal R-value of the pipe insulation.</description>
+      <type>String</type>
+      <units>h-ft^2-R/Btu</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>dwhr_facilities_connected</name>
+      <display_name>Drain Water Heat Recovery: Facilities Connected</display_name>
+      <description>Which facilities are connected for the drain water heat recovery. Use 'none' if there is no drain water heat recovery system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>one</value>
+          <display_name>one</display_name>
+        </choice>
+        <choice>
+          <value>all</value>
+          <display_name>all</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>dwhr_equal_flow</name>
+      <display_name>Drain Water Heat Recovery: Equal Flow</display_name>
+      <description>Whether the drain water heat recovery has equal flow.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>dwhr_efficiency</name>
+      <display_name>Drain Water Heat Recovery: Efficiency</display_name>
+      <description>The efficiency of the drain water heat recovery.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.55</default_value>
+    </argument>
+    <argument>
+      <name>water_fixtures_shower_low_flow</name>
+      <display_name>Hot Water Fixtures: Is Shower Low Flow</display_name>
+      <description>Whether the shower fixture is low flow.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>water_fixtures_sink_low_flow</name>
+      <display_name>Hot Water Fixtures: Is Sink Low Flow</display_name>
+      <description>Whether the sink fixture is low flow.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>water_fixtures_usage_multiplier</name>
+      <display_name>Hot Water Fixtures: Usage Multiplier</display_name>
+      <description>Multiplier on the hot water usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>solar_thermal_system_type</name>
+      <display_name>Solar Thermal: System Type</display_name>
+      <description>The type of solar thermal system. Use 'none' if there is no solar thermal system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>hot water</value>
+          <display_name>hot water</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>solar_thermal_collector_area</name>
+      <display_name>Solar Thermal: Collector Area</display_name>
+      <description>The collector area of the solar thermal system.</description>
+      <type>Double</type>
+      <units>ft^2</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>40</default_value>
+    </argument>
+    <argument>
+      <name>solar_thermal_collector_loop_type</name>
+      <display_name>Solar Thermal: Collector Loop Type</display_name>
+      <description>The collector loop type of the solar thermal system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>liquid direct</default_value>
+      <choices>
+        <choice>
+          <value>liquid direct</value>
+          <display_name>liquid direct</display_name>
+        </choice>
+        <choice>
+          <value>liquid indirect</value>
+          <display_name>liquid indirect</display_name>
+        </choice>
+        <choice>
+          <value>passive thermosyphon</value>
+          <display_name>passive thermosyphon</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>solar_thermal_collector_type</name>
+      <display_name>Solar Thermal: Collector Type</display_name>
+      <description>The collector type of the solar thermal system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>evacuated tube</default_value>
+      <choices>
+        <choice>
+          <value>evacuated tube</value>
+          <display_name>evacuated tube</display_name>
+        </choice>
+        <choice>
+          <value>single glazing black</value>
+          <display_name>single glazing black</display_name>
+        </choice>
+        <choice>
+          <value>double glazing black</value>
+          <display_name>double glazing black</display_name>
+        </choice>
+        <choice>
+          <value>integrated collector storage</value>
+          <display_name>integrated collector storage</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>solar_thermal_collector_azimuth</name>
+      <display_name>Solar Thermal: Collector Azimuth</display_name>
+      <description>The collector azimuth of the solar thermal system. Azimuth is measured clockwise from north (e.g., North=0, East=90, South=180, West=270).</description>
+      <type>Double</type>
+      <units>degrees</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>180</default_value>
+    </argument>
+    <argument>
+      <name>solar_thermal_collector_tilt</name>
+      <display_name>Solar Thermal: Collector Tilt</display_name>
+      <description>The collector tilt of the solar thermal system. Can also enter, e.g., RoofPitch, RoofPitch+20, Latitude, Latitude-15, etc.</description>
+      <type>String</type>
+      <units>degrees</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>RoofPitch</default_value>
+    </argument>
+    <argument>
+      <name>solar_thermal_collector_rated_optical_efficiency</name>
+      <display_name>Solar Thermal: Collector Rated Optical Efficiency</display_name>
+      <description>The collector rated optical efficiency of the solar thermal system.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.5</default_value>
+    </argument>
+    <argument>
+      <name>solar_thermal_collector_rated_thermal_losses</name>
+      <display_name>Solar Thermal: Collector Rated Thermal Losses</display_name>
+      <description>The collector rated thermal losses of the solar thermal system.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.2799</default_value>
+    </argument>
+    <argument>
+      <name>solar_thermal_storage_volume</name>
+      <display_name>Solar Thermal: Storage Volume</display_name>
+      <description>The storage volume of the solar thermal system.</description>
+      <type>String</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>solar_thermal_solar_fraction</name>
+      <display_name>Solar Thermal: Solar Fraction</display_name>
+      <description>The solar fraction of the solar thermal system. If provided, overrides all other solar thermal inputs.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>pv_system_module_type</name>
+      <display_name>PV System: Module Type</display_name>
+      <description>Module type of the PV system. Use 'none' if there is no PV system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>standard</value>
+          <display_name>standard</display_name>
+        </choice>
+        <choice>
+          <value>premium</value>
+          <display_name>premium</display_name>
+        </choice>
+        <choice>
+          <value>thin film</value>
+          <display_name>thin film</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pv_system_location</name>
+      <display_name>PV System: Location</display_name>
+      <description>Location of the PV system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>roof</value>
+          <display_name>roof</display_name>
+        </choice>
+        <choice>
+          <value>ground</value>
+          <display_name>ground</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pv_system_tracking</name>
+      <display_name>PV System: Tracking</display_name>
+      <description>Tracking of the PV system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>fixed</value>
+          <display_name>fixed</display_name>
+        </choice>
+        <choice>
+          <value>1-axis</value>
+          <display_name>1-axis</display_name>
+        </choice>
+        <choice>
+          <value>1-axis backtracked</value>
+          <display_name>1-axis backtracked</display_name>
+        </choice>
+        <choice>
+          <value>2-axis</value>
+          <display_name>2-axis</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pv_system_array_azimuth</name>
+      <display_name>PV System: Array Azimuth</display_name>
+      <description>Array azimuth of the PV system. Azimuth is measured clockwise from north (e.g., North=0, East=90, South=180, West=270).</description>
+      <type>Double</type>
+      <units>degrees</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>180</default_value>
+    </argument>
+    <argument>
+      <name>pv_system_array_tilt</name>
+      <display_name>PV System: Array Tilt</display_name>
+      <description>Array tilt of the PV system. Can also enter, e.g., RoofPitch, RoofPitch+20, Latitude, Latitude-15, etc.</description>
+      <type>String</type>
+      <units>degrees</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>RoofPitch</default_value>
+    </argument>
+    <argument>
+      <name>pv_system_max_power_output</name>
+      <display_name>PV System: Maximum Power Output</display_name>
+      <description>Maximum power output of the PV system. For a shared system, this is the total building maximum power output.</description>
+      <type>Double</type>
+      <units>W</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>4000</default_value>
+    </argument>
+    <argument>
+      <name>pv_system_inverter_efficiency</name>
+      <display_name>PV System: Inverter Efficiency</display_name>
+      <description>Inverter efficiency of the PV system. If there are two PV systems, this will apply to both.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>pv_system_system_losses_fraction</name>
+      <display_name>PV System: System Losses Fraction</display_name>
+      <description>System losses fraction of the PV system. If there are two PV systems, this will apply to both.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>pv_system_num_bedrooms_served</name>
+      <display_name>PV System: Number of Bedrooms Served</display_name>
+      <description>Number of bedrooms served by PV system. Ignored if single-family detached. Used to apportion PV generation to the unit of a SFA/MF building. If there are two PV systems, this will apply to both.</description>
+      <type>Integer</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>3</default_value>
+    </argument>
+    <argument>
+      <name>pv_system_2_module_type</name>
+      <display_name>PV System 2: Module Type</display_name>
+      <description>Module type of the second PV system. Use 'none' if there is no PV system 2.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>standard</value>
+          <display_name>standard</display_name>
+        </choice>
+        <choice>
+          <value>premium</value>
+          <display_name>premium</display_name>
+        </choice>
+        <choice>
+          <value>thin film</value>
+          <display_name>thin film</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pv_system_2_location</name>
+      <display_name>PV System 2: Location</display_name>
+      <description>Location of the second PV system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>roof</value>
+          <display_name>roof</display_name>
+        </choice>
+        <choice>
+          <value>ground</value>
+          <display_name>ground</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pv_system_2_tracking</name>
+      <display_name>PV System 2: Tracking</display_name>
+      <description>Tracking of the second PV system.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>fixed</value>
+          <display_name>fixed</display_name>
+        </choice>
+        <choice>
+          <value>1-axis</value>
+          <display_name>1-axis</display_name>
+        </choice>
+        <choice>
+          <value>1-axis backtracked</value>
+          <display_name>1-axis backtracked</display_name>
+        </choice>
+        <choice>
+          <value>2-axis</value>
+          <display_name>2-axis</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pv_system_2_array_azimuth</name>
+      <display_name>PV System 2: Array Azimuth</display_name>
+      <description>Array azimuth of the second PV system. Azimuth is measured clockwise from north (e.g., North=0, East=90, South=180, West=270).</description>
+      <type>Double</type>
+      <units>degrees</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>180</default_value>
+    </argument>
+    <argument>
+      <name>pv_system_2_array_tilt</name>
+      <display_name>PV System 2: Array Tilt</display_name>
+      <description>Array tilt of the second PV system. Can also enter, e.g., RoofPitch, RoofPitch+20, Latitude, Latitude-15, etc.</description>
+      <type>String</type>
+      <units>degrees</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>RoofPitch</default_value>
+    </argument>
+    <argument>
+      <name>pv_system_2_max_power_output</name>
+      <display_name>PV System 2: Maximum Power Output</display_name>
+      <description>Maximum power output of the second PV system. For a shared system, this is the total building maximum power output.</description>
+      <type>Double</type>
+      <units>W</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>4000</default_value>
+    </argument>
+    <argument>
+      <name>battery_location</name>
+      <display_name>Battery: Location</display_name>
+      <description>The space type for the lithium ion battery location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - vented</value>
+          <display_name>crawlspace - vented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - unvented</value>
+          <display_name>crawlspace - unvented</display_name>
+        </choice>
+        <choice>
+          <value>crawlspace - conditioned</value>
+          <display_name>crawlspace - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>attic - vented</value>
+          <display_name>attic - vented</display_name>
+        </choice>
+        <choice>
+          <value>attic - unvented</value>
+          <display_name>attic - unvented</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>outside</value>
+          <display_name>outside</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>battery_power</name>
+      <display_name>Battery: Rated Power Output</display_name>
+      <description>The rated power output of the lithium ion battery.</description>
+      <type>String</type>
+      <units>W</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>battery_capacity</name>
+      <display_name>Battery: Nominal Capacity</display_name>
+      <description>The nominal capacity of the lithium ion battery.</description>
+      <type>String</type>
+      <units>kWh</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>lighting_present</name>
+      <display_name>Lighting: Present</display_name>
+      <description>Whether there is lighting energy use.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>lighting_interior_fraction_cfl</name>
+      <display_name>Lighting: Interior Fraction CFL</display_name>
+      <description>Fraction of all lamps (interior) that are compact fluorescent. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.1</default_value>
+    </argument>
+    <argument>
+      <name>lighting_interior_fraction_lfl</name>
+      <display_name>Lighting: Interior Fraction LFL</display_name>
+      <description>Fraction of all lamps (interior) that are linear fluorescent. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_interior_fraction_led</name>
+      <display_name>Lighting: Interior Fraction LED</display_name>
+      <description>Fraction of all lamps (interior) that are light emitting diodes. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_interior_usage_multiplier</name>
+      <display_name>Lighting: Interior Usage Multiplier</display_name>
+      <description>Multiplier on the lighting energy usage (interior) that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>lighting_exterior_fraction_cfl</name>
+      <display_name>Lighting: Exterior Fraction CFL</display_name>
+      <description>Fraction of all lamps (exterior) that are compact fluorescent. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_exterior_fraction_lfl</name>
+      <display_name>Lighting: Exterior Fraction LFL</display_name>
+      <description>Fraction of all lamps (exterior) that are linear fluorescent. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_exterior_fraction_led</name>
+      <display_name>Lighting: Exterior Fraction LED</display_name>
+      <description>Fraction of all lamps (exterior) that are light emitting diodes. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_exterior_usage_multiplier</name>
+      <display_name>Lighting: Exterior Usage Multiplier</display_name>
+      <description>Multiplier on the lighting energy usage (exterior) that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>lighting_garage_fraction_cfl</name>
+      <display_name>Lighting: Garage Fraction CFL</display_name>
+      <description>Fraction of all lamps (garage) that are compact fluorescent. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_garage_fraction_lfl</name>
+      <display_name>Lighting: Garage Fraction LFL</display_name>
+      <description>Fraction of all lamps (garage) that are linear fluorescent. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_garage_fraction_led</name>
+      <display_name>Lighting: Garage Fraction LED</display_name>
+      <description>Fraction of all lamps (garage) that are light emitting diodes. Lighting not specified as CFL, LFL, or LED is assumed to be incandescent.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>lighting_garage_usage_multiplier</name>
+      <display_name>Lighting: Garage Usage Multiplier</display_name>
+      <description>Multiplier on the lighting energy usage (garage) that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>holiday_lighting_present</name>
+      <display_name>Holiday Lighting: Present</display_name>
+      <description>Whether there is holiday lighting.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>holiday_lighting_daily_kwh</name>
+      <display_name>Holiday Lighting: Daily Consumption</display_name>
+      <description>The daily energy consumption for holiday lighting (exterior).</description>
+      <type>String</type>
+      <units>kWh/day</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>holiday_lighting_period</name>
+      <display_name>Holiday Lighting: Period</display_name>
+      <description>Enter a date like "Nov 25 - Jan 5".</description>
+      <type>String</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+    </argument>
+    <argument>
+      <name>dehumidifier_type</name>
+      <display_name>Dehumidifier: Type</display_name>
+      <description>The type of dehumidifier.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>portable</value>
+          <display_name>portable</display_name>
+        </choice>
+        <choice>
+          <value>whole-home</value>
+          <display_name>whole-home</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>dehumidifier_efficiency_type</name>
+      <display_name>Dehumidifier: Efficiency Type</display_name>
+      <description>The efficiency type of dehumidifier.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>IntegratedEnergyFactor</default_value>
+      <choices>
+        <choice>
+          <value>EnergyFactor</value>
+          <display_name>EnergyFactor</display_name>
+        </choice>
+        <choice>
+          <value>IntegratedEnergyFactor</value>
+          <display_name>IntegratedEnergyFactor</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>dehumidifier_efficiency</name>
+      <display_name>Dehumidifier: Efficiency</display_name>
+      <description>The efficiency of the dehumidifier.</description>
+      <type>Double</type>
+      <units>liters/kWh</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1.5</default_value>
+    </argument>
+    <argument>
+      <name>dehumidifier_capacity</name>
+      <display_name>Dehumidifier: Capacity</display_name>
+      <description>The capacity (water removal rate) of the dehumidifier.</description>
+      <type>Double</type>
+      <units>pint/day</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>40</default_value>
+    </argument>
+    <argument>
+      <name>dehumidifier_rh_setpoint</name>
+      <display_name>Dehumidifier: Relative Humidity Setpoint</display_name>
+      <description>The relative humidity setpoint of the dehumidifier.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0.5</default_value>
+    </argument>
+    <argument>
+      <name>dehumidifier_fraction_dehumidification_load_served</name>
+      <display_name>Dehumidifier: Fraction Dehumidification Load Served</display_name>
+      <description>The dehumidification load served fraction of the dehumidifier.</description>
+      <type>Double</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_location</name>
+      <display_name>Clothes Washer: Location</display_name>
+      <description>The space type for the clothes washer location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>clothes_washer_efficiency_type</name>
+      <display_name>Clothes Washer: Efficiency Type</display_name>
+      <description>The efficiency type of the clothes washer.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>IntegratedModifiedEnergyFactor</default_value>
+      <choices>
+        <choice>
+          <value>ModifiedEnergyFactor</value>
+          <display_name>ModifiedEnergyFactor</display_name>
+        </choice>
+        <choice>
+          <value>IntegratedModifiedEnergyFactor</value>
+          <display_name>IntegratedModifiedEnergyFactor</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>clothes_washer_efficiency</name>
+      <display_name>Clothes Washer: Efficiency</display_name>
+      <description>The efficiency of the clothes washer.</description>
+      <type>String</type>
+      <units>ft^3/kWh-cyc</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_rated_annual_kwh</name>
+      <display_name>Clothes Washer: Rated Annual Consumption</display_name>
+      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_label_electric_rate</name>
+      <display_name>Clothes Washer: Label Electric Rate</display_name>
+      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating.</description>
+      <type>String</type>
+      <units>$/kWh</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_label_gas_rate</name>
+      <display_name>Clothes Washer: Label Gas Rate</display_name>
+      <description>The annual energy consumed by the clothes washer, as rated, obtained from the EnergyGuide label. This includes both the appliance electricity consumption and the energy required for water heating.</description>
+      <type>String</type>
+      <units>$/therm</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_label_annual_gas_cost</name>
+      <display_name>Clothes Washer: Label Annual Cost with Gas DHW</display_name>
+      <description>The annual cost of using the system under test conditions. Input is obtained from the EnergyGuide label.</description>
+      <type>String</type>
+      <units>$</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_label_usage</name>
+      <display_name>Clothes Washer: Label Usage</display_name>
+      <description>The clothes washer loads per week.</description>
+      <type>String</type>
+      <units>cyc/wk</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_capacity</name>
+      <display_name>Clothes Washer: Drum Volume</display_name>
+      <description>Volume of the washer drum. Obtained from the EnergyStar website or the manufacturer's literature.</description>
+      <type>String</type>
+      <units>ft^3</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_washer_usage_multiplier</name>
+      <display_name>Clothes Washer: Usage Multiplier</display_name>
+      <description>Multiplier on the clothes washer energy and hot water usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>clothes_dryer_location</name>
+      <display_name>Clothes Dryer: Location</display_name>
+      <description>The space type for the clothes dryer location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>clothes_dryer_fuel_type</name>
+      <display_name>Clothes Dryer: Fuel Type</display_name>
+      <description>Type of fuel used by the clothes dryer.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>natural gas</default_value>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>coal</value>
+          <display_name>coal</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>clothes_dryer_efficiency_type</name>
+      <display_name>Clothes Dryer: Efficiency Type</display_name>
+      <description>The efficiency type of the clothes dryer.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>CombinedEnergyFactor</default_value>
+      <choices>
+        <choice>
+          <value>EnergyFactor</value>
+          <display_name>EnergyFactor</display_name>
+        </choice>
+        <choice>
+          <value>CombinedEnergyFactor</value>
+          <display_name>CombinedEnergyFactor</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>clothes_dryer_efficiency</name>
+      <display_name>Clothes Dryer: Efficiency</display_name>
+      <description>The efficiency of the clothes dryer.</description>
+      <type>String</type>
+      <units>lb/kWh</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_dryer_vented_flow_rate</name>
+      <display_name>Clothes Dryer: Vented Flow Rate</display_name>
+      <description>The exhaust flow rate of the vented clothes dryer.</description>
+      <type>String</type>
+      <units>CFM</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>clothes_dryer_usage_multiplier</name>
+      <display_name>Clothes Dryer: Usage Multiplier</display_name>
+      <description>Multiplier on the clothes dryer energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>dishwasher_location</name>
+      <display_name>Dishwasher: Location</display_name>
+      <description>The space type for the dishwasher location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>dishwasher_efficiency_type</name>
+      <display_name>Dishwasher: Efficiency Type</display_name>
+      <description>The efficiency type of dishwasher.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>RatedAnnualkWh</default_value>
+      <choices>
+        <choice>
+          <value>RatedAnnualkWh</value>
+          <display_name>RatedAnnualkWh</display_name>
+        </choice>
+        <choice>
+          <value>EnergyFactor</value>
+          <display_name>EnergyFactor</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>dishwasher_efficiency</name>
+      <display_name>Dishwasher: Efficiency</display_name>
+      <description>The efficiency of the dishwasher.</description>
+      <type>String</type>
+      <units>RatedAnnualkWh or EnergyFactor</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>dishwasher_label_electric_rate</name>
+      <display_name>Dishwasher: Label Electric Rate</display_name>
+      <description>The label electric rate of the dishwasher.</description>
+      <type>String</type>
+      <units>$/kWh</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>dishwasher_label_gas_rate</name>
+      <display_name>Dishwasher: Label Gas Rate</display_name>
+      <description>The label gas rate of the dishwasher.</description>
+      <type>String</type>
+      <units>$/therm</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>dishwasher_label_annual_gas_cost</name>
+      <display_name>Dishwasher: Label Annual Gas Cost</display_name>
+      <description>The label annual gas cost of the dishwasher.</description>
+      <type>String</type>
+      <units>$</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>dishwasher_label_usage</name>
+      <display_name>Dishwasher: Label Usage</display_name>
+      <description>The dishwasher loads per week.</description>
+      <type>String</type>
+      <units>cyc/wk</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>dishwasher_place_setting_capacity</name>
+      <display_name>Dishwasher: Number of Place Settings</display_name>
+      <description>The number of place settings for the unit. Data obtained from manufacturer's literature.</description>
+      <type>String</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>dishwasher_usage_multiplier</name>
+      <display_name>Dishwasher: Usage Multiplier</display_name>
+      <description>Multiplier on the dishwasher energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>refrigerator_location</name>
+      <display_name>Refrigerator: Location</display_name>
+      <description>The space type for the refrigerator location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>refrigerator_rated_annual_kwh</name>
+      <display_name>Refrigerator: Rated Annual Consumption</display_name>
+      <description>The EnergyGuide rated annual energy consumption for a refrigerator.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>refrigerator_usage_multiplier</name>
+      <display_name>Refrigerator: Usage Multiplier</display_name>
+      <description>Multiplier on the refrigerator energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>extra_refrigerator_location</name>
+      <display_name>Extra Refrigerator: Location</display_name>
+      <description>The space type for the extra refrigerator location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>extra_refrigerator_rated_annual_kwh</name>
+      <display_name>Extra Refrigerator: Rated Annual Consumption</display_name>
+      <description>The EnergyGuide rated annual energy consumption for an extra rrefrigerator.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>extra_refrigerator_usage_multiplier</name>
+      <display_name>Extra Refrigerator: Usage Multiplier</display_name>
+      <description>Multiplier on the extra refrigerator energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>freezer_location</name>
+      <display_name>Freezer: Location</display_name>
+      <description>The space type for the freezer location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>freezer_rated_annual_kwh</name>
+      <display_name>Freezer: Rated Annual Consumption</display_name>
+      <description>The EnergyGuide rated annual energy consumption for a freezer.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>freezer_usage_multiplier</name>
+      <display_name>Freezer: Usage Multiplier</display_name>
+      <description>Multiplier on the freezer energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>cooking_range_oven_location</name>
+      <display_name>Cooking Range/Oven: Location</display_name>
+      <description>The space type for the cooking range/oven location.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+      <choices>
+        <choice>
+          <value>auto</value>
+          <display_name>auto</display_name>
+        </choice>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>living space</value>
+          <display_name>living space</display_name>
+        </choice>
+        <choice>
+          <value>basement - conditioned</value>
+          <display_name>basement - conditioned</display_name>
+        </choice>
+        <choice>
+          <value>basement - unconditioned</value>
+          <display_name>basement - unconditioned</display_name>
+        </choice>
+        <choice>
+          <value>garage</value>
+          <display_name>garage</display_name>
+        </choice>
+        <choice>
+          <value>other housing unit</value>
+          <display_name>other housing unit</display_name>
+        </choice>
+        <choice>
+          <value>other heated space</value>
+          <display_name>other heated space</display_name>
+        </choice>
+        <choice>
+          <value>other multifamily buffer space</value>
+          <display_name>other multifamily buffer space</display_name>
+        </choice>
+        <choice>
+          <value>other non-freezing space</value>
+          <display_name>other non-freezing space</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooking_range_oven_fuel_type</name>
+      <display_name>Cooking Range/Oven: Fuel Type</display_name>
+      <description>Type of fuel used by the cooking range/oven.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>natural gas</default_value>
+      <choices>
+        <choice>
+          <value>electricity</value>
+          <display_name>electricity</display_name>
+        </choice>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>coal</value>
+          <display_name>coal</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooking_range_oven_is_induction</name>
+      <display_name>Cooking Range/Oven: Is Induction</display_name>
+      <description>Whether the cooking range is induction.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooking_range_oven_is_convection</name>
+      <display_name>Cooking Range/Oven: Is Convection</display_name>
+      <description>Whether the oven is convection.</description>
+      <type>Boolean</type>
+      <required>false</required>
+      <model_dependent>false</model_dependent>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>cooking_range_oven_usage_multiplier</name>
+      <display_name>Cooking Range/Oven: Usage Multiplier</display_name>
+      <description>Multiplier on the cooking range/oven energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>ceiling_fan_present</name>
+      <display_name>Ceiling Fan: Present</display_name>
+      <description>Whether there is are any ceiling fans.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>ceiling_fan_efficiency</name>
+      <display_name>Ceiling Fan: Efficiency</display_name>
+      <description>The efficiency rating of the ceiling fan(s) at medium speed.</description>
+      <type>String</type>
+      <units>CFM/W</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>ceiling_fan_quantity</name>
+      <display_name>Ceiling Fan: Quantity</display_name>
+      <description>Total number of ceiling fans.</description>
+      <type>String</type>
+      <units>#</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>ceiling_fan_cooling_setpoint_temp_offset</name>
+      <display_name>Ceiling Fan: Cooling Setpoint Temperature Offset</display_name>
+      <description>The setpoint temperature offset during cooling season for the ceiling fan(s). Only applies if ceiling fan quantity is greater than zero.</description>
+      <type>Double</type>
+      <units>deg-F</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_television_present</name>
+      <display_name>Misc Plug Loads: Television Present</display_name>
+      <description>Whether there are televisions.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>true</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_television_annual_kwh</name>
+      <display_name>Misc Plug Loads: Television Annual kWh</display_name>
+      <description>The annual energy consumption of the television plug loads.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_television_usage_multiplier</name>
+      <display_name>Misc Plug Loads: Television Usage Multiplier</display_name>
+      <description>Multiplier on the television energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_other_annual_kwh</name>
+      <display_name>Misc Plug Loads: Other Annual kWh</display_name>
+      <description>The annual energy consumption of the other residual plug loads.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_other_frac_sensible</name>
+      <display_name>Misc Plug Loads: Other Sensible Fraction</display_name>
+      <description>Fraction of other residual plug loads' internal gains that are sensible.</description>
+      <type>String</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_other_frac_latent</name>
+      <display_name>Misc Plug Loads: Other Latent Fraction</display_name>
+      <description>Fraction of other residual plug loads' internal gains that are latent.</description>
+      <type>String</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_other_usage_multiplier</name>
+      <display_name>Misc Plug Loads: Other Usage Multiplier</display_name>
+      <description>Multiplier on the other energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_well_pump_present</name>
+      <display_name>Misc Plug Loads: Well Pump Present</display_name>
+      <description>Whether there is a well pump.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_well_pump_annual_kwh</name>
+      <display_name>Misc Plug Loads: Well Pump Annual kWh</display_name>
+      <description>The annual energy consumption of the well pump plug loads.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_well_pump_usage_multiplier</name>
+      <display_name>Misc Plug Loads: Well Pump Usage Multiplier</display_name>
+      <description>Multiplier on the well pump energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_vehicle_present</name>
+      <display_name>Misc Plug Loads: Vehicle Present</display_name>
+      <description>Whether there is an electric vehicle.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_vehicle_annual_kwh</name>
+      <display_name>Misc Plug Loads: Vehicle Annual kWh</display_name>
+      <description>The annual energy consumption of the electric vehicle plug loads.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_plug_loads_vehicle_usage_multiplier</name>
+      <display_name>Misc Plug Loads: Vehicle Usage Multiplier</display_name>
+      <description>Multiplier on the electric vehicle energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_grill_present</name>
+      <display_name>Misc Fuel Loads: Grill Present</display_name>
+      <description>Whether there is a fuel loads grill.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_grill_fuel_type</name>
+      <display_name>Misc Fuel Loads: Grill Fuel Type</display_name>
+      <description>The fuel type of the fuel loads grill.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>natural gas</default_value>
+      <choices>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>wood pellets</value>
+          <display_name>wood pellets</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_grill_annual_therm</name>
+      <display_name>Misc Fuel Loads: Grill Annual therm</display_name>
+      <description>The annual energy consumption of the fuel loads grill.</description>
+      <type>String</type>
+      <units>therm/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_grill_usage_multiplier</name>
+      <display_name>Misc Fuel Loads: Grill Usage Multiplier</display_name>
+      <description>Multiplier on the fuel loads grill energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_lighting_present</name>
+      <display_name>Misc Fuel Loads: Lighting Present</display_name>
+      <description>Whether there is fuel loads lighting.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_lighting_fuel_type</name>
+      <display_name>Misc Fuel Loads: Lighting Fuel Type</display_name>
+      <description>The fuel type of the fuel loads lighting.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>natural gas</default_value>
+      <choices>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>wood pellets</value>
+          <display_name>wood pellets</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_lighting_annual_therm</name>
+      <display_name>Misc Fuel Loads: Lighting Annual therm</display_name>
+      <description>The annual energy consumption of the fuel loads lighting.</description>
+      <type>String</type>
+      <units>therm/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_lighting_usage_multiplier</name>
+      <display_name>Misc Fuel Loads: Lighting Usage Multiplier</display_name>
+      <description>Multiplier on the fuel loads lighting energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_fireplace_present</name>
+      <display_name>Misc Fuel Loads: Fireplace Present</display_name>
+      <description>Whether there is fuel loads fireplace.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_fireplace_fuel_type</name>
+      <display_name>Misc Fuel Loads: Fireplace Fuel Type</display_name>
+      <description>The fuel type of the fuel loads fireplace.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>natural gas</default_value>
+      <choices>
+        <choice>
+          <value>natural gas</value>
+          <display_name>natural gas</display_name>
+        </choice>
+        <choice>
+          <value>fuel oil</value>
+          <display_name>fuel oil</display_name>
+        </choice>
+        <choice>
+          <value>propane</value>
+          <display_name>propane</display_name>
+        </choice>
+        <choice>
+          <value>wood</value>
+          <display_name>wood</display_name>
+        </choice>
+        <choice>
+          <value>wood pellets</value>
+          <display_name>wood pellets</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_fireplace_annual_therm</name>
+      <display_name>Misc Fuel Loads: Fireplace Annual therm</display_name>
+      <description>The annual energy consumption of the fuel loads fireplace.</description>
+      <type>String</type>
+      <units>therm/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_fireplace_frac_sensible</name>
+      <display_name>Misc Fuel Loads: Fireplace Sensible Fraction</display_name>
+      <description>Fraction of fireplace residual fuel loads' internal gains that are sensible.</description>
+      <type>String</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_fireplace_frac_latent</name>
+      <display_name>Misc Fuel Loads: Fireplace Latent Fraction</display_name>
+      <description>Fraction of fireplace residual fuel loads' internal gains that are latent.</description>
+      <type>String</type>
+      <units>Frac</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>misc_fuel_loads_fireplace_usage_multiplier</name>
+      <display_name>Misc Fuel Loads: Fireplace Usage Multiplier</display_name>
+      <description>Multiplier on the fuel loads fireplace energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>0</default_value>
+    </argument>
+    <argument>
+      <name>pool_present</name>
+      <display_name>Pool: Present</display_name>
+      <description>Whether there is a pool.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pool_pump_annual_kwh</name>
+      <display_name>Pool: Pump Annual kWh</display_name>
+      <description>The annual energy consumption of the pool pump.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>pool_pump_usage_multiplier</name>
+      <display_name>Pool: Pump Usage Multiplier</display_name>
+      <description>Multiplier on the pool pump energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>pool_heater_type</name>
+      <display_name>Pool: Heater Type</display_name>
+      <description>The type of pool heater. Use 'none' if there is no pool heater.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>electric resistance</value>
+          <display_name>electric resistance</display_name>
+        </choice>
+        <choice>
+          <value>gas fired</value>
+          <display_name>gas fired</display_name>
+        </choice>
+        <choice>
+          <value>heat pump</value>
+          <display_name>heat pump</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>pool_heater_annual_kwh</name>
+      <display_name>Pool: Heater Annual kWh</display_name>
+      <description>The annual energy consumption of the electric resistance pool heater.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>pool_heater_annual_therm</name>
+      <display_name>Pool: Heater Annual therm</display_name>
+      <description>The annual energy consumption of the gas fired pool heater.</description>
+      <type>String</type>
+      <units>therm/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>pool_heater_usage_multiplier</name>
+      <display_name>Pool: Heater Usage Multiplier</display_name>
+      <description>Multiplier on the pool heater energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>hot_tub_present</name>
+      <display_name>Hot Tub: Present</display_name>
+      <description>Whether there is a hot tub.</description>
+      <type>Boolean</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>false</default_value>
+      <choices>
+        <choice>
+          <value>true</value>
+          <display_name>true</display_name>
+        </choice>
+        <choice>
+          <value>false</value>
+          <display_name>false</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>hot_tub_pump_annual_kwh</name>
+      <display_name>Hot Tub: Pump Annual kWh</display_name>
+      <description>The annual energy consumption of the hot tub pump.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>hot_tub_pump_usage_multiplier</name>
+      <display_name>Hot Tub: Pump Usage Multiplier</display_name>
+      <description>Multiplier on the hot tub pump energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
+    <argument>
+      <name>hot_tub_heater_type</name>
+      <display_name>Hot Tub: Heater Type</display_name>
+      <description>The type of hot tub heater. Use 'none' if there is no hot tub heater.</description>
+      <type>Choice</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>none</default_value>
+      <choices>
+        <choice>
+          <value>none</value>
+          <display_name>none</display_name>
+        </choice>
+        <choice>
+          <value>electric resistance</value>
+          <display_name>electric resistance</display_name>
+        </choice>
+        <choice>
+          <value>gas fired</value>
+          <display_name>gas fired</display_name>
+        </choice>
+        <choice>
+          <value>heat pump</value>
+          <display_name>heat pump</display_name>
+        </choice>
+      </choices>
+    </argument>
+    <argument>
+      <name>hot_tub_heater_annual_kwh</name>
+      <display_name>Hot Tub: Heater Annual kWh</display_name>
+      <description>The annual energy consumption of the electric resistance hot tub heater.</description>
+      <type>String</type>
+      <units>kWh/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>hot_tub_heater_annual_therm</name>
+      <display_name>Hot Tub: Heater Annual therm</display_name>
+      <description>The annual energy consumption of the gas fired hot tub heater.</description>
+      <type>String</type>
+      <units>therm/yr</units>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>auto</default_value>
+    </argument>
+    <argument>
+      <name>hot_tub_heater_usage_multiplier</name>
+      <display_name>Hot Tub: Heater Usage Multiplier</display_name>
+      <description>Multiplier on the hot tub heater energy usage that can reflect, e.g., high/low usage occupants.</description>
+      <type>Double</type>
+      <required>true</required>
+      <model_dependent>false</model_dependent>
+      <default_value>1</default_value>
+    </argument>
   </arguments>
-  <outputs/>
-  <provenances/>
+  <outputs />
+  <provenances />
   <tags>
     <tag>Whole Building.Space Types</tag>
   </tags>
@@ -57,7 +5957,31 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>32BF074D</checksum>
+      <checksum>2157707D</checksum>
+    </file>
+    <file>
+      <filename>constants.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>89EB6AEB</checksum>
+    </file>
+    <file>
+      <filename>geometry.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>A628308E</checksum>
+    </file>
+    <file>
+      <filename>unit_conversions.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>6B1FBD5D</checksum>
+    </file>
+    <file>
+      <filename>util.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>resource</usage_type>
+      <checksum>ECE5603C</checksum>
     </file>
   </files>
 </measure>

--- a/example_project/xml_building/17/unit 1.xml
+++ b/example_project/xml_building/17/unit 1.xml
@@ -1,0 +1,591 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<HPXML xmlns='http://hpxmlonline.com/2019/10' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://hpxmlonline.com/2019/10' schemaVersion='4.0'>
+  <XMLTransactionHeaderInformation>
+    <XMLType>HPXML</XMLType>
+    <XMLGeneratedBy>Hand</XMLGeneratedBy>
+    <CreatedDateAndTime>2021-12-01T15:17:56-07:00</CreatedDateAndTime>
+    <Transaction>create</Transaction>
+  </XMLTransactionHeaderInformation>
+  <SoftwareInfo>
+    <SoftwareProgramUsed>urbanopt-example-geojson-project</SoftwareProgramUsed>
+    <extension>
+      <SimulationControl>
+        <Timestep>60</Timestep>
+        <BeginMonth>1</BeginMonth>
+        <BeginDayOfMonth>1</BeginDayOfMonth>
+        <EndMonth>12</EndMonth>
+        <EndDayOfMonth>31</EndDayOfMonth>
+        <CalendarYear>2017</CalendarYear>
+      </SimulationControl>
+    </extension>
+  </SoftwareInfo>
+  <Building>
+    <BuildingID id='MyBuilding'/>
+    <Site>
+      <SiteID id='SiteID'/>
+      <Address>
+        <StateCode>NY</StateCode>
+      </Address>
+    </Site>
+    <ProjectStatus>
+      <EventType>proposed workscope</EventType>
+    </ProjectStatus>
+    <BuildingDetails>
+      <BuildingSummary>
+        <Site>
+          <Surroundings>attached on one side</Surroundings>
+          <VerticalSurroundings>no units above or below</VerticalSurroundings>
+          <AzimuthOfFrontOfHome>180</AzimuthOfFrontOfHome>
+        </Site>
+        <BuildingConstruction>
+          <ResidentialFacilityType>single-family attached</ResidentialFacilityType>
+          <NumberofConditionedFloors>2.0</NumberofConditionedFloors>
+          <NumberofConditionedFloorsAboveGrade>2.0</NumberofConditionedFloorsAboveGrade>
+          <AverageCeilingHeight>8.0</AverageCeilingHeight>
+          <NumberofBedrooms>1</NumberofBedrooms>
+          <ConditionedFloorArea>4580.0</ConditionedFloorArea>
+          <ConditionedBuildingVolume>36640.0</ConditionedBuildingVolume>
+        </BuildingConstruction>
+      </BuildingSummary>
+      <ClimateandRiskZones>
+        <ClimateZoneIECC>
+          <Year>2006</Year>
+          <ClimateZone>5A</ClimateZone>
+        </ClimateZoneIECC>
+        <WeatherStation>
+          <SystemIdentifier id='WeatherStation'/>
+          <Name>USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3</Name>
+          <extension>
+            <EPWFilePath>../../../weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw</EPWFilePath>
+          </extension>
+        </WeatherStation>
+      </ClimateandRiskZones>
+      <Enclosure>
+        <AirInfiltration>
+          <AirInfiltrationMeasurement>
+            <SystemIdentifier id='AirInfiltrationMeasurement1'/>
+            <HousePressure>50.0</HousePressure>
+            <BuildingAirLeakage>
+              <UnitofMeasure>ACH</UnitofMeasure>
+              <AirLeakage>3.0</AirLeakage>
+            </BuildingAirLeakage>
+            <InfiltrationVolume>36640.0</InfiltrationVolume>
+          </AirInfiltrationMeasurement>
+        </AirInfiltration>
+        <Attics>
+          <Attic>
+            <SystemIdentifier id='Attic1'/>
+            <AtticType>
+              <Attic>
+                <Vented>true</Vented>
+              </Attic>
+            </AtticType>
+            <AttachedToRoof idref='Roof1'/>
+            <AttachedToRoof idref='Roof2'/>
+            <AttachedToWall idref='Wall11'/>
+            <AttachedToWall idref='Wall12'/>
+            <AttachedToFrameFloor idref='FrameFloor1'/>
+          </Attic>
+        </Attics>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='Foundation1'/>
+            <FoundationType>
+              <SlabOnGrade/>
+            </FoundationType>
+            <AttachedToSlab idref='Slab1'/>
+          </Foundation>
+        </Foundations>
+        <Roofs>
+          <Roof>
+            <SystemIdentifier id='Roof1'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>0</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof1Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof2'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>180</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof2Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+        </Roofs>
+        <Walls>
+          <Wall>
+            <SystemIdentifier id='Wall1'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>0</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall1Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall3'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall3Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall5'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>180</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall5Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall9'/>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall9Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall11'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <AtticWallType>gable</AtticWallType>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall11Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall12'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall12Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+        </Walls>
+        <FrameFloors>
+          <FrameFloor>
+            <SystemIdentifier id='FrameFloor1'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FrameFloor1Insulation'/>
+              <AssemblyEffectiveRValue>38.46153846</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+        </FrameFloors>
+        <Slabs>
+          <Slab>
+            <SystemIdentifier id='Slab1'/>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <ExposedPerimeter>135.4</ExposedPerimeter>
+            <DepthBelowGrade>0.0</DepthBelowGrade>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab1PerimeterInsulation'/>
+              <Layer>
+                <NominalRValue>10.0</NominalRValue>
+                <InsulationDepth>2.0</InsulationDepth>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab1UnderSlabInsulation'/>
+              <Layer>
+                <NominalRValue>0.0</NominalRValue>
+                <InsulationWidth>0.0</InsulationWidth>
+              </Layer>
+            </UnderSlabInsulation>
+          </Slab>
+        </Slabs>
+        <Windows>
+          <Window>
+            <SystemIdentifier id='Window1'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window4'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window11'/>
+            <Area>97.5</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.8</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window12'/>
+            <Area>97.5</Area>
+            <Azimuth>90</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.8</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window29'/>
+            <Area>51.3</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.7</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall5'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window31'/>
+            <Area>46.1</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.9</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall5'/>
+          </Window>
+        </Windows>
+        <Doors>
+          <Door>
+            <SystemIdentifier id='Door1'/>
+            <AttachedToWall idref='Wall5'/>
+            <Area>20.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+        </Doors>
+      </Enclosure>
+      <Systems>
+        <HVAC>
+          <HVACPlant>
+            <PrimarySystems>
+              <PrimaryHeatingSystem idref='HeatingSystem1'/>
+              <PrimaryCoolingSystem idref='CoolingSystem1'/>
+            </PrimarySystems>
+            <HeatingSystem>
+              <SystemIdentifier id='HeatingSystem1'/>
+              <DistributionSystem idref='HVACDistribution1'/>
+              <HeatingSystemType>
+                <Furnace/>
+              </HeatingSystemType>
+              <HeatingSystemFuel>fuel oil</HeatingSystemFuel>
+              <AnnualHeatingEfficiency>
+                <Units>AFUE</Units>
+                <Value>0.85</Value>
+              </AnnualHeatingEfficiency>
+              <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
+            </HeatingSystem>
+            <CoolingSystem>
+              <SystemIdentifier id='CoolingSystem1'/>
+              <CoolingSystemType>room air conditioner</CoolingSystemType>
+              <CoolingSystemFuel>electricity</CoolingSystemFuel>
+              <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
+              <AnnualCoolingEfficiency>
+                <Units>EER</Units>
+                <Value>8.5</Value>
+              </AnnualCoolingEfficiency>
+            </CoolingSystem>
+          </HVACPlant>
+          <HVACControl>
+            <SystemIdentifier id='HVACControl1'/>
+            <ControlType>manual thermostat</ControlType>
+            <SetpointTempHeatingSeason>71.0</SetpointTempHeatingSeason>
+            <SetpointTempCoolingSeason>76.0</SetpointTempCoolingSeason>
+          </HVACControl>
+          <HVACDistribution>
+            <SystemIdentifier id='HVACDistribution1'/>
+            <DistributionSystemType>
+              <AirDistribution>
+                <AirDistributionType>regular velocity</AirDistributionType>
+                <DuctLeakageMeasurement>
+                  <DuctType>supply</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <DuctLeakageMeasurement>
+                  <DuctType>return</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <Ducts>
+                  <DuctType>supply</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+                <Ducts>
+                  <DuctType>return</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+              </AirDistribution>
+            </DistributionSystemType>
+            <ConditionedFloorAreaServed>4580.0</ConditionedFloorAreaServed>
+          </HVACDistribution>
+        </HVAC>
+        <MechanicalVentilation>
+          <VentilationFans>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan1'/>
+              <FanType>energy recovery ventilator</FanType>
+              <UsedForWholeBuildingVentilation>true</UsedForWholeBuildingVentilation>
+              <TotalRecoveryEfficiency>0.48</TotalRecoveryEfficiency>
+              <SensibleRecoveryEfficiency>0.72</SensibleRecoveryEfficiency>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan2'/>
+              <FanLocation>kitchen</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan3'/>
+              <FanLocation>bath</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+          </VentilationFans>
+        </MechanicalVentilation>
+        <WaterHeating>
+          <WaterHeatingSystem>
+            <SystemIdentifier id='WaterHeatingSystem1'/>
+            <FuelType>fuel oil</FuelType>
+            <WaterHeaterType>storage water heater</WaterHeaterType>
+            <TankVolume>40.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <EnergyFactor>0.53</EnergyFactor>
+          </WaterHeatingSystem>
+          <HotWaterDistribution>
+            <SystemIdentifier id='HotWaterDistribution1'/>
+            <SystemType>
+              <Standard/>
+            </SystemType>
+          </HotWaterDistribution>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture1'/>
+            <WaterFixtureType>shower head</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture2'/>
+            <WaterFixtureType>faucet</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+        </WaterHeating>
+      </Systems>
+      <Appliances>
+        <ClothesWasher>
+          <SystemIdentifier id='ClothesWasher1'/>
+          <IntegratedModifiedEnergyFactor>2.92</IntegratedModifiedEnergyFactor>
+          <RatedAnnualkWh>75.0</RatedAnnualkWh>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>7.0</LabelAnnualGasCost>
+          <LabelUsage>6.0</LabelUsage>
+          <Capacity>4.5</Capacity>
+        </ClothesWasher>
+        <ClothesDryer>
+          <SystemIdentifier id='ClothesDryer1'/>
+          <FuelType>fuel oil</FuelType>
+          <CombinedEnergyFactor>3.03</CombinedEnergyFactor>
+        </ClothesDryer>
+        <Dishwasher>
+          <SystemIdentifier id='Dishwasher1'/>
+          <RatedAnnualkWh>199.0</RatedAnnualkWh>
+          <PlaceSettingCapacity>12</PlaceSettingCapacity>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>18.0</LabelAnnualGasCost>
+          <LabelUsage>4.0</LabelUsage>
+        </Dishwasher>
+        <Refrigerator>
+          <SystemIdentifier id='Refrigerator1'/>
+          <RatedAnnualkWh>423.0</RatedAnnualkWh>
+          <PrimaryIndicator>true</PrimaryIndicator>
+        </Refrigerator>
+        <CookingRange>
+          <SystemIdentifier id='CookingRange1'/>
+          <FuelType>fuel oil</FuelType>
+        </CookingRange>
+        <Oven>
+          <SystemIdentifier id='Oven1'/>
+        </Oven>
+      </Appliances>
+      <Lighting>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup1'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.1</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup2'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup3'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup4'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup5'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup6'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup7'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup8'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup9'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <CeilingFan>
+          <SystemIdentifier id='CeilingFan1'/>
+        </CeilingFan>
+      </Lighting>
+      <MiscLoads>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad1'/>
+          <PlugLoadType>TV other</PlugLoadType>
+        </PlugLoad>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad2'/>
+          <PlugLoadType>other</PlugLoadType>
+        </PlugLoad>
+      </MiscLoads>
+    </BuildingDetails>
+  </Building>
+</HPXML>

--- a/example_project/xml_building/17/unit 2.xml
+++ b/example_project/xml_building/17/unit 2.xml
@@ -1,0 +1,564 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<HPXML xmlns='http://hpxmlonline.com/2019/10' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://hpxmlonline.com/2019/10' schemaVersion='4.0'>
+  <XMLTransactionHeaderInformation>
+    <XMLType>HPXML</XMLType>
+    <XMLGeneratedBy>Hand</XMLGeneratedBy>
+    <CreatedDateAndTime>2021-12-01T15:18:06-07:00</CreatedDateAndTime>
+    <Transaction>create</Transaction>
+  </XMLTransactionHeaderInformation>
+  <SoftwareInfo>
+    <SoftwareProgramUsed>urbanopt-example-geojson-project</SoftwareProgramUsed>
+    <extension>
+      <SimulationControl>
+        <Timestep>60</Timestep>
+        <BeginMonth>1</BeginMonth>
+        <BeginDayOfMonth>1</BeginDayOfMonth>
+        <EndMonth>12</EndMonth>
+        <EndDayOfMonth>31</EndDayOfMonth>
+        <CalendarYear>2017</CalendarYear>
+      </SimulationControl>
+    </extension>
+  </SoftwareInfo>
+  <Building>
+    <BuildingID id='MyBuilding'/>
+    <Site>
+      <SiteID id='SiteID'/>
+      <Address>
+        <StateCode>NY</StateCode>
+      </Address>
+    </Site>
+    <ProjectStatus>
+      <EventType>proposed workscope</EventType>
+    </ProjectStatus>
+    <BuildingDetails>
+      <BuildingSummary>
+        <Site>
+          <Surroundings>attached on two sides</Surroundings>
+          <VerticalSurroundings>no units above or below</VerticalSurroundings>
+          <AzimuthOfFrontOfHome>180</AzimuthOfFrontOfHome>
+        </Site>
+        <BuildingConstruction>
+          <ResidentialFacilityType>single-family attached</ResidentialFacilityType>
+          <NumberofConditionedFloors>2.0</NumberofConditionedFloors>
+          <NumberofConditionedFloorsAboveGrade>2.0</NumberofConditionedFloorsAboveGrade>
+          <AverageCeilingHeight>8.0</AverageCeilingHeight>
+          <NumberofBedrooms>1</NumberofBedrooms>
+          <ConditionedFloorArea>4580.0</ConditionedFloorArea>
+          <ConditionedBuildingVolume>36640.0</ConditionedBuildingVolume>
+        </BuildingConstruction>
+      </BuildingSummary>
+      <ClimateandRiskZones>
+        <ClimateZoneIECC>
+          <Year>2006</Year>
+          <ClimateZone>5A</ClimateZone>
+        </ClimateZoneIECC>
+        <WeatherStation>
+          <SystemIdentifier id='WeatherStation'/>
+          <Name>USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3</Name>
+          <extension>
+            <EPWFilePath>../../../weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw</EPWFilePath>
+          </extension>
+        </WeatherStation>
+      </ClimateandRiskZones>
+      <Enclosure>
+        <AirInfiltration>
+          <AirInfiltrationMeasurement>
+            <SystemIdentifier id='AirInfiltrationMeasurement1'/>
+            <HousePressure>50.0</HousePressure>
+            <BuildingAirLeakage>
+              <UnitofMeasure>ACH</UnitofMeasure>
+              <AirLeakage>3.0</AirLeakage>
+            </BuildingAirLeakage>
+            <InfiltrationVolume>36640.0</InfiltrationVolume>
+          </AirInfiltrationMeasurement>
+        </AirInfiltration>
+        <Attics>
+          <Attic>
+            <SystemIdentifier id='Attic1'/>
+            <AtticType>
+              <Attic>
+                <Vented>true</Vented>
+              </Attic>
+            </AtticType>
+            <AttachedToRoof idref='Roof1'/>
+            <AttachedToRoof idref='Roof2'/>
+            <AttachedToWall idref='Wall11'/>
+            <AttachedToWall idref='Wall12'/>
+            <AttachedToFrameFloor idref='FrameFloor1'/>
+          </Attic>
+        </Attics>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='Foundation1'/>
+            <FoundationType>
+              <SlabOnGrade/>
+            </FoundationType>
+            <AttachedToSlab idref='Slab1'/>
+          </Foundation>
+        </Foundations>
+        <Roofs>
+          <Roof>
+            <SystemIdentifier id='Roof1'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>0</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof1Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof2'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>180</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof2Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+        </Roofs>
+        <Walls>
+          <Wall>
+            <SystemIdentifier id='Wall1'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>0</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall1Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall3'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>180</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall3Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall7'/>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall7Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall9'/>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall9Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall11'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall11Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall12'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall12Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+        </Walls>
+        <FrameFloors>
+          <FrameFloor>
+            <SystemIdentifier id='FrameFloor1'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FrameFloor1Insulation'/>
+              <AssemblyEffectiveRValue>38.46153846</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+        </FrameFloors>
+        <Slabs>
+          <Slab>
+            <SystemIdentifier id='Slab1'/>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <ExposedPerimeter>67.7</ExposedPerimeter>
+            <DepthBelowGrade>0.0</DepthBelowGrade>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab1PerimeterInsulation'/>
+              <Layer>
+                <NominalRValue>10.0</NominalRValue>
+                <InsulationDepth>2.0</InsulationDepth>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab1UnderSlabInsulation'/>
+              <Layer>
+                <NominalRValue>0.0</NominalRValue>
+                <InsulationWidth>0.0</InsulationWidth>
+              </Layer>
+            </UnderSlabInsulation>
+          </Slab>
+        </Slabs>
+        <Windows>
+          <Window>
+            <SystemIdentifier id='Window1'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window2'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window11'/>
+            <Area>51.3</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.7</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window14'/>
+            <Area>46.1</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.9</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+        </Windows>
+        <Doors>
+          <Door>
+            <SystemIdentifier id='Door1'/>
+            <AttachedToWall idref='Wall3'/>
+            <Area>20.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+        </Doors>
+      </Enclosure>
+      <Systems>
+        <HVAC>
+          <HVACPlant>
+            <PrimarySystems>
+              <PrimaryHeatingSystem idref='HeatingSystem1'/>
+              <PrimaryCoolingSystem idref='CoolingSystem1'/>
+            </PrimarySystems>
+            <HeatingSystem>
+              <SystemIdentifier id='HeatingSystem1'/>
+              <DistributionSystem idref='HVACDistribution1'/>
+              <HeatingSystemType>
+                <Furnace/>
+              </HeatingSystemType>
+              <HeatingSystemFuel>fuel oil</HeatingSystemFuel>
+              <AnnualHeatingEfficiency>
+                <Units>AFUE</Units>
+                <Value>0.85</Value>
+              </AnnualHeatingEfficiency>
+              <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
+            </HeatingSystem>
+            <CoolingSystem>
+              <SystemIdentifier id='CoolingSystem1'/>
+              <CoolingSystemType>room air conditioner</CoolingSystemType>
+              <CoolingSystemFuel>electricity</CoolingSystemFuel>
+              <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
+              <AnnualCoolingEfficiency>
+                <Units>EER</Units>
+                <Value>8.5</Value>
+              </AnnualCoolingEfficiency>
+            </CoolingSystem>
+          </HVACPlant>
+          <HVACControl>
+            <SystemIdentifier id='HVACControl1'/>
+            <ControlType>manual thermostat</ControlType>
+            <SetpointTempHeatingSeason>71.0</SetpointTempHeatingSeason>
+            <SetpointTempCoolingSeason>76.0</SetpointTempCoolingSeason>
+          </HVACControl>
+          <HVACDistribution>
+            <SystemIdentifier id='HVACDistribution1'/>
+            <DistributionSystemType>
+              <AirDistribution>
+                <AirDistributionType>regular velocity</AirDistributionType>
+                <DuctLeakageMeasurement>
+                  <DuctType>supply</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <DuctLeakageMeasurement>
+                  <DuctType>return</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <Ducts>
+                  <DuctType>supply</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+                <Ducts>
+                  <DuctType>return</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+              </AirDistribution>
+            </DistributionSystemType>
+            <ConditionedFloorAreaServed>4580.0</ConditionedFloorAreaServed>
+          </HVACDistribution>
+        </HVAC>
+        <MechanicalVentilation>
+          <VentilationFans>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan1'/>
+              <FanType>energy recovery ventilator</FanType>
+              <UsedForWholeBuildingVentilation>true</UsedForWholeBuildingVentilation>
+              <TotalRecoveryEfficiency>0.48</TotalRecoveryEfficiency>
+              <SensibleRecoveryEfficiency>0.72</SensibleRecoveryEfficiency>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan2'/>
+              <FanLocation>kitchen</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan3'/>
+              <FanLocation>bath</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+          </VentilationFans>
+        </MechanicalVentilation>
+        <WaterHeating>
+          <WaterHeatingSystem>
+            <SystemIdentifier id='WaterHeatingSystem1'/>
+            <FuelType>fuel oil</FuelType>
+            <WaterHeaterType>storage water heater</WaterHeaterType>
+            <TankVolume>40.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <EnergyFactor>0.53</EnergyFactor>
+          </WaterHeatingSystem>
+          <HotWaterDistribution>
+            <SystemIdentifier id='HotWaterDistribution1'/>
+            <SystemType>
+              <Standard/>
+            </SystemType>
+          </HotWaterDistribution>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture1'/>
+            <WaterFixtureType>shower head</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture2'/>
+            <WaterFixtureType>faucet</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+        </WaterHeating>
+      </Systems>
+      <Appliances>
+        <ClothesWasher>
+          <SystemIdentifier id='ClothesWasher1'/>
+          <IntegratedModifiedEnergyFactor>2.92</IntegratedModifiedEnergyFactor>
+          <RatedAnnualkWh>75.0</RatedAnnualkWh>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>7.0</LabelAnnualGasCost>
+          <LabelUsage>6.0</LabelUsage>
+          <Capacity>4.5</Capacity>
+        </ClothesWasher>
+        <ClothesDryer>
+          <SystemIdentifier id='ClothesDryer1'/>
+          <FuelType>fuel oil</FuelType>
+          <CombinedEnergyFactor>3.03</CombinedEnergyFactor>
+        </ClothesDryer>
+        <Dishwasher>
+          <SystemIdentifier id='Dishwasher1'/>
+          <RatedAnnualkWh>199.0</RatedAnnualkWh>
+          <PlaceSettingCapacity>12</PlaceSettingCapacity>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>18.0</LabelAnnualGasCost>
+          <LabelUsage>4.0</LabelUsage>
+        </Dishwasher>
+        <Refrigerator>
+          <SystemIdentifier id='Refrigerator1'/>
+          <RatedAnnualkWh>423.0</RatedAnnualkWh>
+          <PrimaryIndicator>true</PrimaryIndicator>
+        </Refrigerator>
+        <CookingRange>
+          <SystemIdentifier id='CookingRange1'/>
+          <FuelType>fuel oil</FuelType>
+        </CookingRange>
+        <Oven>
+          <SystemIdentifier id='Oven1'/>
+        </Oven>
+      </Appliances>
+      <Lighting>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup1'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.1</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup2'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup3'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup4'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup5'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup6'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup7'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup8'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup9'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <CeilingFan>
+          <SystemIdentifier id='CeilingFan1'/>
+        </CeilingFan>
+      </Lighting>
+      <MiscLoads>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad1'/>
+          <PlugLoadType>TV other</PlugLoadType>
+        </PlugLoad>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad2'/>
+          <PlugLoadType>other</PlugLoadType>
+        </PlugLoad>
+      </MiscLoads>
+    </BuildingDetails>
+  </Building>
+</HPXML>

--- a/example_project/xml_building/17/unit 3.xml
+++ b/example_project/xml_building/17/unit 3.xml
@@ -1,0 +1,564 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<HPXML xmlns='http://hpxmlonline.com/2019/10' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://hpxmlonline.com/2019/10' schemaVersion='4.0'>
+  <XMLTransactionHeaderInformation>
+    <XMLType>HPXML</XMLType>
+    <XMLGeneratedBy>Hand</XMLGeneratedBy>
+    <CreatedDateAndTime>2021-12-01T15:18:17-07:00</CreatedDateAndTime>
+    <Transaction>create</Transaction>
+  </XMLTransactionHeaderInformation>
+  <SoftwareInfo>
+    <SoftwareProgramUsed>urbanopt-example-geojson-project</SoftwareProgramUsed>
+    <extension>
+      <SimulationControl>
+        <Timestep>60</Timestep>
+        <BeginMonth>1</BeginMonth>
+        <BeginDayOfMonth>1</BeginDayOfMonth>
+        <EndMonth>12</EndMonth>
+        <EndDayOfMonth>31</EndDayOfMonth>
+        <CalendarYear>2017</CalendarYear>
+      </SimulationControl>
+    </extension>
+  </SoftwareInfo>
+  <Building>
+    <BuildingID id='MyBuilding'/>
+    <Site>
+      <SiteID id='SiteID'/>
+      <Address>
+        <StateCode>NY</StateCode>
+      </Address>
+    </Site>
+    <ProjectStatus>
+      <EventType>proposed workscope</EventType>
+    </ProjectStatus>
+    <BuildingDetails>
+      <BuildingSummary>
+        <Site>
+          <Surroundings>attached on two sides</Surroundings>
+          <VerticalSurroundings>no units above or below</VerticalSurroundings>
+          <AzimuthOfFrontOfHome>180</AzimuthOfFrontOfHome>
+        </Site>
+        <BuildingConstruction>
+          <ResidentialFacilityType>single-family attached</ResidentialFacilityType>
+          <NumberofConditionedFloors>2.0</NumberofConditionedFloors>
+          <NumberofConditionedFloorsAboveGrade>2.0</NumberofConditionedFloorsAboveGrade>
+          <AverageCeilingHeight>8.0</AverageCeilingHeight>
+          <NumberofBedrooms>1</NumberofBedrooms>
+          <ConditionedFloorArea>4580.0</ConditionedFloorArea>
+          <ConditionedBuildingVolume>36640.0</ConditionedBuildingVolume>
+        </BuildingConstruction>
+      </BuildingSummary>
+      <ClimateandRiskZones>
+        <ClimateZoneIECC>
+          <Year>2006</Year>
+          <ClimateZone>5A</ClimateZone>
+        </ClimateZoneIECC>
+        <WeatherStation>
+          <SystemIdentifier id='WeatherStation'/>
+          <Name>USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3</Name>
+          <extension>
+            <EPWFilePath>../../../weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw</EPWFilePath>
+          </extension>
+        </WeatherStation>
+      </ClimateandRiskZones>
+      <Enclosure>
+        <AirInfiltration>
+          <AirInfiltrationMeasurement>
+            <SystemIdentifier id='AirInfiltrationMeasurement1'/>
+            <HousePressure>50.0</HousePressure>
+            <BuildingAirLeakage>
+              <UnitofMeasure>ACH</UnitofMeasure>
+              <AirLeakage>3.0</AirLeakage>
+            </BuildingAirLeakage>
+            <InfiltrationVolume>36640.0</InfiltrationVolume>
+          </AirInfiltrationMeasurement>
+        </AirInfiltration>
+        <Attics>
+          <Attic>
+            <SystemIdentifier id='Attic1'/>
+            <AtticType>
+              <Attic>
+                <Vented>true</Vented>
+              </Attic>
+            </AtticType>
+            <AttachedToRoof idref='Roof1'/>
+            <AttachedToRoof idref='Roof2'/>
+            <AttachedToWall idref='Wall11'/>
+            <AttachedToWall idref='Wall12'/>
+            <AttachedToFrameFloor idref='FrameFloor1'/>
+          </Attic>
+        </Attics>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='Foundation1'/>
+            <FoundationType>
+              <SlabOnGrade/>
+            </FoundationType>
+            <AttachedToSlab idref='Slab1'/>
+          </Foundation>
+        </Foundations>
+        <Roofs>
+          <Roof>
+            <SystemIdentifier id='Roof1'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>0</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof1Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof2'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>180</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof2Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+        </Roofs>
+        <Walls>
+          <Wall>
+            <SystemIdentifier id='Wall1'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>0</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall1Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall3'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>180</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall3Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall7'/>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall7Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall9'/>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall9Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall11'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall11Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall12'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall12Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+        </Walls>
+        <FrameFloors>
+          <FrameFloor>
+            <SystemIdentifier id='FrameFloor1'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FrameFloor1Insulation'/>
+              <AssemblyEffectiveRValue>38.46153846</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+        </FrameFloors>
+        <Slabs>
+          <Slab>
+            <SystemIdentifier id='Slab1'/>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <ExposedPerimeter>67.7</ExposedPerimeter>
+            <DepthBelowGrade>0.0</DepthBelowGrade>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab1PerimeterInsulation'/>
+              <Layer>
+                <NominalRValue>10.0</NominalRValue>
+                <InsulationDepth>2.0</InsulationDepth>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab1UnderSlabInsulation'/>
+              <Layer>
+                <NominalRValue>0.0</NominalRValue>
+                <InsulationWidth>0.0</InsulationWidth>
+              </Layer>
+            </UnderSlabInsulation>
+          </Slab>
+        </Slabs>
+        <Windows>
+          <Window>
+            <SystemIdentifier id='Window1'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window4'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window11'/>
+            <Area>51.3</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.7</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window13'/>
+            <Area>46.1</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.9</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+        </Windows>
+        <Doors>
+          <Door>
+            <SystemIdentifier id='Door1'/>
+            <AttachedToWall idref='Wall3'/>
+            <Area>20.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+        </Doors>
+      </Enclosure>
+      <Systems>
+        <HVAC>
+          <HVACPlant>
+            <PrimarySystems>
+              <PrimaryHeatingSystem idref='HeatingSystem1'/>
+              <PrimaryCoolingSystem idref='CoolingSystem1'/>
+            </PrimarySystems>
+            <HeatingSystem>
+              <SystemIdentifier id='HeatingSystem1'/>
+              <DistributionSystem idref='HVACDistribution1'/>
+              <HeatingSystemType>
+                <Furnace/>
+              </HeatingSystemType>
+              <HeatingSystemFuel>fuel oil</HeatingSystemFuel>
+              <AnnualHeatingEfficiency>
+                <Units>AFUE</Units>
+                <Value>0.85</Value>
+              </AnnualHeatingEfficiency>
+              <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
+            </HeatingSystem>
+            <CoolingSystem>
+              <SystemIdentifier id='CoolingSystem1'/>
+              <CoolingSystemType>room air conditioner</CoolingSystemType>
+              <CoolingSystemFuel>electricity</CoolingSystemFuel>
+              <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
+              <AnnualCoolingEfficiency>
+                <Units>EER</Units>
+                <Value>8.5</Value>
+              </AnnualCoolingEfficiency>
+            </CoolingSystem>
+          </HVACPlant>
+          <HVACControl>
+            <SystemIdentifier id='HVACControl1'/>
+            <ControlType>manual thermostat</ControlType>
+            <SetpointTempHeatingSeason>71.0</SetpointTempHeatingSeason>
+            <SetpointTempCoolingSeason>76.0</SetpointTempCoolingSeason>
+          </HVACControl>
+          <HVACDistribution>
+            <SystemIdentifier id='HVACDistribution1'/>
+            <DistributionSystemType>
+              <AirDistribution>
+                <AirDistributionType>regular velocity</AirDistributionType>
+                <DuctLeakageMeasurement>
+                  <DuctType>supply</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <DuctLeakageMeasurement>
+                  <DuctType>return</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <Ducts>
+                  <DuctType>supply</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+                <Ducts>
+                  <DuctType>return</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+              </AirDistribution>
+            </DistributionSystemType>
+            <ConditionedFloorAreaServed>4580.0</ConditionedFloorAreaServed>
+          </HVACDistribution>
+        </HVAC>
+        <MechanicalVentilation>
+          <VentilationFans>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan1'/>
+              <FanType>energy recovery ventilator</FanType>
+              <UsedForWholeBuildingVentilation>true</UsedForWholeBuildingVentilation>
+              <TotalRecoveryEfficiency>0.48</TotalRecoveryEfficiency>
+              <SensibleRecoveryEfficiency>0.72</SensibleRecoveryEfficiency>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan2'/>
+              <FanLocation>kitchen</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan3'/>
+              <FanLocation>bath</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+          </VentilationFans>
+        </MechanicalVentilation>
+        <WaterHeating>
+          <WaterHeatingSystem>
+            <SystemIdentifier id='WaterHeatingSystem1'/>
+            <FuelType>fuel oil</FuelType>
+            <WaterHeaterType>storage water heater</WaterHeaterType>
+            <TankVolume>40.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <EnergyFactor>0.53</EnergyFactor>
+          </WaterHeatingSystem>
+          <HotWaterDistribution>
+            <SystemIdentifier id='HotWaterDistribution1'/>
+            <SystemType>
+              <Standard/>
+            </SystemType>
+          </HotWaterDistribution>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture1'/>
+            <WaterFixtureType>shower head</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture2'/>
+            <WaterFixtureType>faucet</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+        </WaterHeating>
+      </Systems>
+      <Appliances>
+        <ClothesWasher>
+          <SystemIdentifier id='ClothesWasher1'/>
+          <IntegratedModifiedEnergyFactor>2.92</IntegratedModifiedEnergyFactor>
+          <RatedAnnualkWh>75.0</RatedAnnualkWh>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>7.0</LabelAnnualGasCost>
+          <LabelUsage>6.0</LabelUsage>
+          <Capacity>4.5</Capacity>
+        </ClothesWasher>
+        <ClothesDryer>
+          <SystemIdentifier id='ClothesDryer1'/>
+          <FuelType>fuel oil</FuelType>
+          <CombinedEnergyFactor>3.03</CombinedEnergyFactor>
+        </ClothesDryer>
+        <Dishwasher>
+          <SystemIdentifier id='Dishwasher1'/>
+          <RatedAnnualkWh>199.0</RatedAnnualkWh>
+          <PlaceSettingCapacity>12</PlaceSettingCapacity>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>18.0</LabelAnnualGasCost>
+          <LabelUsage>4.0</LabelUsage>
+        </Dishwasher>
+        <Refrigerator>
+          <SystemIdentifier id='Refrigerator1'/>
+          <RatedAnnualkWh>423.0</RatedAnnualkWh>
+          <PrimaryIndicator>true</PrimaryIndicator>
+        </Refrigerator>
+        <CookingRange>
+          <SystemIdentifier id='CookingRange1'/>
+          <FuelType>fuel oil</FuelType>
+        </CookingRange>
+        <Oven>
+          <SystemIdentifier id='Oven1'/>
+        </Oven>
+      </Appliances>
+      <Lighting>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup1'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.1</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup2'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup3'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup4'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup5'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup6'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup7'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup8'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup9'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <CeilingFan>
+          <SystemIdentifier id='CeilingFan1'/>
+        </CeilingFan>
+      </Lighting>
+      <MiscLoads>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad1'/>
+          <PlugLoadType>TV other</PlugLoadType>
+        </PlugLoad>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad2'/>
+          <PlugLoadType>other</PlugLoadType>
+        </PlugLoad>
+      </MiscLoads>
+    </BuildingDetails>
+  </Building>
+</HPXML>

--- a/example_project/xml_building/17/unit 4.xml
+++ b/example_project/xml_building/17/unit 4.xml
@@ -1,0 +1,591 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<HPXML xmlns='http://hpxmlonline.com/2019/10' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='http://hpxmlonline.com/2019/10' schemaVersion='4.0'>
+  <XMLTransactionHeaderInformation>
+    <XMLType>HPXML</XMLType>
+    <XMLGeneratedBy>Hand</XMLGeneratedBy>
+    <CreatedDateAndTime>2021-12-01T15:18:30-07:00</CreatedDateAndTime>
+    <Transaction>create</Transaction>
+  </XMLTransactionHeaderInformation>
+  <SoftwareInfo>
+    <SoftwareProgramUsed>urbanopt-example-geojson-project</SoftwareProgramUsed>
+    <extension>
+      <SimulationControl>
+        <Timestep>60</Timestep>
+        <BeginMonth>1</BeginMonth>
+        <BeginDayOfMonth>1</BeginDayOfMonth>
+        <EndMonth>12</EndMonth>
+        <EndDayOfMonth>31</EndDayOfMonth>
+        <CalendarYear>2017</CalendarYear>
+      </SimulationControl>
+    </extension>
+  </SoftwareInfo>
+  <Building>
+    <BuildingID id='MyBuilding'/>
+    <Site>
+      <SiteID id='SiteID'/>
+      <Address>
+        <StateCode>NY</StateCode>
+      </Address>
+    </Site>
+    <ProjectStatus>
+      <EventType>proposed workscope</EventType>
+    </ProjectStatus>
+    <BuildingDetails>
+      <BuildingSummary>
+        <Site>
+          <Surroundings>attached on one side</Surroundings>
+          <VerticalSurroundings>no units above or below</VerticalSurroundings>
+          <AzimuthOfFrontOfHome>180</AzimuthOfFrontOfHome>
+        </Site>
+        <BuildingConstruction>
+          <ResidentialFacilityType>single-family attached</ResidentialFacilityType>
+          <NumberofConditionedFloors>2.0</NumberofConditionedFloors>
+          <NumberofConditionedFloorsAboveGrade>2.0</NumberofConditionedFloorsAboveGrade>
+          <AverageCeilingHeight>8.0</AverageCeilingHeight>
+          <NumberofBedrooms>1</NumberofBedrooms>
+          <ConditionedFloorArea>4580.0</ConditionedFloorArea>
+          <ConditionedBuildingVolume>36640.0</ConditionedBuildingVolume>
+        </BuildingConstruction>
+      </BuildingSummary>
+      <ClimateandRiskZones>
+        <ClimateZoneIECC>
+          <Year>2006</Year>
+          <ClimateZone>5A</ClimateZone>
+        </ClimateZoneIECC>
+        <WeatherStation>
+          <SystemIdentifier id='WeatherStation'/>
+          <Name>USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3</Name>
+          <extension>
+            <EPWFilePath>../../../weather/USA_NY_Buffalo-Greater.Buffalo.Intl.AP.725280_TMY3.epw</EPWFilePath>
+          </extension>
+        </WeatherStation>
+      </ClimateandRiskZones>
+      <Enclosure>
+        <AirInfiltration>
+          <AirInfiltrationMeasurement>
+            <SystemIdentifier id='AirInfiltrationMeasurement1'/>
+            <HousePressure>50.0</HousePressure>
+            <BuildingAirLeakage>
+              <UnitofMeasure>ACH</UnitofMeasure>
+              <AirLeakage>3.0</AirLeakage>
+            </BuildingAirLeakage>
+            <InfiltrationVolume>36640.0</InfiltrationVolume>
+          </AirInfiltrationMeasurement>
+        </AirInfiltration>
+        <Attics>
+          <Attic>
+            <SystemIdentifier id='Attic1'/>
+            <AtticType>
+              <Attic>
+                <Vented>true</Vented>
+              </Attic>
+            </AtticType>
+            <AttachedToRoof idref='Roof1'/>
+            <AttachedToRoof idref='Roof2'/>
+            <AttachedToWall idref='Wall11'/>
+            <AttachedToWall idref='Wall12'/>
+            <AttachedToFrameFloor idref='FrameFloor1'/>
+          </Attic>
+        </Attics>
+        <Foundations>
+          <Foundation>
+            <SystemIdentifier id='Foundation1'/>
+            <FoundationType>
+              <SlabOnGrade/>
+            </FoundationType>
+            <AttachedToSlab idref='Slab1'/>
+          </Foundation>
+        </Foundations>
+        <Roofs>
+          <Roof>
+            <SystemIdentifier id='Roof1'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>0</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof1Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+          <Roof>
+            <SystemIdentifier id='Roof2'/>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <Area>1280.1</Area>
+            <Azimuth>180</Azimuth>
+            <RoofColor>medium</RoofColor>
+            <Pitch>6.0</Pitch>
+            <RadiantBarrier>false</RadiantBarrier>
+            <Insulation>
+              <SystemIdentifier id='Roof2Insulation'/>
+              <AssemblyEffectiveRValue>2.3</AssemblyEffectiveRValue>
+            </Insulation>
+          </Roof>
+        </Roofs>
+        <Walls>
+          <Wall>
+            <SystemIdentifier id='Wall1'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>0</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall1Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall3'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>541.4</Area>
+            <Azimuth>180</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall3Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall7'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall7Insulation'/>
+              <AssemblyEffectiveRValue>16.66666667</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall9'/>
+            <ExteriorAdjacentTo>other housing unit</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>1082.8</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall9Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall11'/>
+            <ExteriorAdjacentTo>outside</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <AtticWallType>gable</AtticWallType>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>270</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall11Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+          <Wall>
+            <SystemIdentifier id='Wall12'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>attic - vented</InteriorAdjacentTo>
+            <WallType>
+              <WoodStud/>
+            </WallType>
+            <Area>572.5</Area>
+            <Azimuth>90</Azimuth>
+            <Color>medium</Color>
+            <Insulation>
+              <SystemIdentifier id='Wall12Insulation'/>
+              <AssemblyEffectiveRValue>4.0</AssemblyEffectiveRValue>
+            </Insulation>
+          </Wall>
+        </Walls>
+        <FrameFloors>
+          <FrameFloor>
+            <SystemIdentifier id='FrameFloor1'/>
+            <ExteriorAdjacentTo>attic - vented</ExteriorAdjacentTo>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <Insulation>
+              <SystemIdentifier id='FrameFloor1Insulation'/>
+              <AssemblyEffectiveRValue>38.46153846</AssemblyEffectiveRValue>
+            </Insulation>
+          </FrameFloor>
+        </FrameFloors>
+        <Slabs>
+          <Slab>
+            <SystemIdentifier id='Slab1'/>
+            <InteriorAdjacentTo>living space</InteriorAdjacentTo>
+            <Area>2290.0</Area>
+            <ExposedPerimeter>135.4</ExposedPerimeter>
+            <DepthBelowGrade>0.0</DepthBelowGrade>
+            <PerimeterInsulation>
+              <SystemIdentifier id='Slab1PerimeterInsulation'/>
+              <Layer>
+                <NominalRValue>10.0</NominalRValue>
+                <InsulationDepth>2.0</InsulationDepth>
+              </Layer>
+            </PerimeterInsulation>
+            <UnderSlabInsulation>
+              <SystemIdentifier id='Slab1UnderSlabInsulation'/>
+              <Layer>
+                <NominalRValue>0.0</NominalRValue>
+                <InsulationWidth>0.0</InsulationWidth>
+              </Layer>
+            </UnderSlabInsulation>
+          </Slab>
+        </Slabs>
+        <Windows>
+          <Window>
+            <SystemIdentifier id='Window1'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window5'/>
+            <Area>48.7</Area>
+            <Azimuth>0</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.6</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall1'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window11'/>
+            <Area>51.3</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.7</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window14'/>
+            <Area>46.1</Area>
+            <Azimuth>180</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.9</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall3'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window20'/>
+            <Area>97.5</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>9.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>12.8</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall7'/>
+          </Window>
+          <Window>
+            <SystemIdentifier id='Window22'/>
+            <Area>97.5</Area>
+            <Azimuth>270</Azimuth>
+            <UFactor>0.32</UFactor>
+            <SHGC>0.4</SHGC>
+            <Overhangs>
+              <Depth>2.0</Depth>
+              <DistanceToTopOfWindow>1.0</DistanceToTopOfWindow>
+              <DistanceToBottomOfWindow>4.8</DistanceToBottomOfWindow>
+            </Overhangs>
+            <AttachedToWall idref='Wall7'/>
+          </Window>
+        </Windows>
+        <Doors>
+          <Door>
+            <SystemIdentifier id='Door1'/>
+            <AttachedToWall idref='Wall3'/>
+            <Area>20.0</Area>
+            <Azimuth>180</Azimuth>
+            <RValue>4.4</RValue>
+          </Door>
+        </Doors>
+      </Enclosure>
+      <Systems>
+        <HVAC>
+          <HVACPlant>
+            <PrimarySystems>
+              <PrimaryHeatingSystem idref='HeatingSystem1'/>
+              <PrimaryCoolingSystem idref='CoolingSystem1'/>
+            </PrimarySystems>
+            <HeatingSystem>
+              <SystemIdentifier id='HeatingSystem1'/>
+              <DistributionSystem idref='HVACDistribution1'/>
+              <HeatingSystemType>
+                <Furnace/>
+              </HeatingSystemType>
+              <HeatingSystemFuel>fuel oil</HeatingSystemFuel>
+              <AnnualHeatingEfficiency>
+                <Units>AFUE</Units>
+                <Value>0.85</Value>
+              </AnnualHeatingEfficiency>
+              <FractionHeatLoadServed>1.0</FractionHeatLoadServed>
+            </HeatingSystem>
+            <CoolingSystem>
+              <SystemIdentifier id='CoolingSystem1'/>
+              <CoolingSystemType>room air conditioner</CoolingSystemType>
+              <CoolingSystemFuel>electricity</CoolingSystemFuel>
+              <FractionCoolLoadServed>1.0</FractionCoolLoadServed>
+              <AnnualCoolingEfficiency>
+                <Units>EER</Units>
+                <Value>8.5</Value>
+              </AnnualCoolingEfficiency>
+            </CoolingSystem>
+          </HVACPlant>
+          <HVACControl>
+            <SystemIdentifier id='HVACControl1'/>
+            <ControlType>manual thermostat</ControlType>
+            <SetpointTempHeatingSeason>71.0</SetpointTempHeatingSeason>
+            <SetpointTempCoolingSeason>76.0</SetpointTempCoolingSeason>
+          </HVACControl>
+          <HVACDistribution>
+            <SystemIdentifier id='HVACDistribution1'/>
+            <DistributionSystemType>
+              <AirDistribution>
+                <AirDistributionType>regular velocity</AirDistributionType>
+                <DuctLeakageMeasurement>
+                  <DuctType>supply</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <DuctLeakageMeasurement>
+                  <DuctType>return</DuctType>
+                  <DuctLeakage>
+                    <Units>Percent</Units>
+                    <Value>0.1</Value>
+                    <TotalOrToOutside>to outside</TotalOrToOutside>
+                  </DuctLeakage>
+                </DuctLeakageMeasurement>
+                <Ducts>
+                  <DuctType>supply</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+                <Ducts>
+                  <DuctType>return</DuctType>
+                  <DuctInsulationRValue>8.0</DuctInsulationRValue>
+                </Ducts>
+              </AirDistribution>
+            </DistributionSystemType>
+            <ConditionedFloorAreaServed>4580.0</ConditionedFloorAreaServed>
+          </HVACDistribution>
+        </HVAC>
+        <MechanicalVentilation>
+          <VentilationFans>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan1'/>
+              <FanType>energy recovery ventilator</FanType>
+              <UsedForWholeBuildingVentilation>true</UsedForWholeBuildingVentilation>
+              <TotalRecoveryEfficiency>0.48</TotalRecoveryEfficiency>
+              <SensibleRecoveryEfficiency>0.72</SensibleRecoveryEfficiency>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan2'/>
+              <FanLocation>kitchen</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+            <VentilationFan>
+              <SystemIdentifier id='VentilationFan3'/>
+              <FanLocation>bath</FanLocation>
+              <UsedForLocalVentilation>true</UsedForLocalVentilation>
+            </VentilationFan>
+          </VentilationFans>
+        </MechanicalVentilation>
+        <WaterHeating>
+          <WaterHeatingSystem>
+            <SystemIdentifier id='WaterHeatingSystem1'/>
+            <FuelType>fuel oil</FuelType>
+            <WaterHeaterType>storage water heater</WaterHeaterType>
+            <TankVolume>40.0</TankVolume>
+            <FractionDHWLoadServed>1.0</FractionDHWLoadServed>
+            <EnergyFactor>0.53</EnergyFactor>
+          </WaterHeatingSystem>
+          <HotWaterDistribution>
+            <SystemIdentifier id='HotWaterDistribution1'/>
+            <SystemType>
+              <Standard/>
+            </SystemType>
+          </HotWaterDistribution>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture1'/>
+            <WaterFixtureType>shower head</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+          <WaterFixture>
+            <SystemIdentifier id='WaterFixture2'/>
+            <WaterFixtureType>faucet</WaterFixtureType>
+            <LowFlow>false</LowFlow>
+          </WaterFixture>
+        </WaterHeating>
+      </Systems>
+      <Appliances>
+        <ClothesWasher>
+          <SystemIdentifier id='ClothesWasher1'/>
+          <IntegratedModifiedEnergyFactor>2.92</IntegratedModifiedEnergyFactor>
+          <RatedAnnualkWh>75.0</RatedAnnualkWh>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>7.0</LabelAnnualGasCost>
+          <LabelUsage>6.0</LabelUsage>
+          <Capacity>4.5</Capacity>
+        </ClothesWasher>
+        <ClothesDryer>
+          <SystemIdentifier id='ClothesDryer1'/>
+          <FuelType>fuel oil</FuelType>
+          <CombinedEnergyFactor>3.03</CombinedEnergyFactor>
+        </ClothesDryer>
+        <Dishwasher>
+          <SystemIdentifier id='Dishwasher1'/>
+          <RatedAnnualkWh>199.0</RatedAnnualkWh>
+          <PlaceSettingCapacity>12</PlaceSettingCapacity>
+          <LabelElectricRate>0.12</LabelElectricRate>
+          <LabelGasRate>1.09</LabelGasRate>
+          <LabelAnnualGasCost>18.0</LabelAnnualGasCost>
+          <LabelUsage>4.0</LabelUsage>
+        </Dishwasher>
+        <Refrigerator>
+          <SystemIdentifier id='Refrigerator1'/>
+          <RatedAnnualkWh>423.0</RatedAnnualkWh>
+          <PrimaryIndicator>true</PrimaryIndicator>
+        </Refrigerator>
+        <CookingRange>
+          <SystemIdentifier id='CookingRange1'/>
+          <FuelType>fuel oil</FuelType>
+        </CookingRange>
+        <Oven>
+          <SystemIdentifier id='Oven1'/>
+        </Oven>
+      </Appliances>
+      <Lighting>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup1'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.1</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup2'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup3'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <CompactFluorescent/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup4'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup5'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup6'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <FluorescentTube/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup7'/>
+          <Location>interior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup8'/>
+          <Location>exterior</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <LightingGroup>
+          <SystemIdentifier id='LightingGroup9'/>
+          <Location>garage</Location>
+          <FractionofUnitsInLocation>0.0</FractionofUnitsInLocation>
+          <LightingType>
+            <LightEmittingDiode/>
+          </LightingType>
+        </LightingGroup>
+        <CeilingFan>
+          <SystemIdentifier id='CeilingFan1'/>
+        </CeilingFan>
+      </Lighting>
+      <MiscLoads>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad1'/>
+          <PlugLoadType>TV other</PlugLoadType>
+        </PlugLoad>
+        <PlugLoad>
+          <SystemIdentifier id='PlugLoad2'/>
+          <PlugLoadType>other</PlugLoadType>
+        </PlugLoad>
+      </MiscLoads>
+    </BuildingDetails>
+  </Building>
+</HPXML>


### PR DESCRIPTION
Optionally point to pre-made HPXMLs vs creating them on the fly using `BuildResidentialHPXML`.

The idea here is to optionally supply a feature-level `hpxml_directory` GeoJSON field. The field is a subfolder (a string corresponding to feature ID) of `example_project/xml_building` which contains unit-specific HPXML files. See [here](https://github.com/urbanopt/urbanopt-example-geojson-project/tree/custom-hpxmls/example_project/xml_building/17) for an example. When `hpxml_directory` is populated, it tells the `BuildResidentialModel` meta measure to skip application of the `BuildResidentialHPXML` measure, and instead just translate the referenced unit-specific HPXML files without first creating any HPXML files.

```
type: "Feature",
properties: {
    id: "17",
    name: "Residential 4",
    type: "Building",
    building_type: "Single-Family Attached",
    floor_area: 18320,
    footprint_area: 9160,
    number_of_stories_above_ground: 2,
    number_of_stories: 2,
    number_of_bedrooms: 6,
    foundation_type: "slab",
    attic_type: "attic - vented",
    system_type: "Residential - furnace and room air conditioner",
    heating_system_fuel_type: "fuel oil",
    number_of_residential_units: 4,
    template: "Residential IECC 2015 - Customizable Template Sep 2020",
    hpxml_directory: "17"
```

Companion PRs:
* https://github.com/urbanopt/urbanopt-geojson-gem/pull/212
* https://github.com/urbanopt/urbanopt.github.io/pull/149