### PR TITLE
Residential: set absolute path for weather filename

### DIFF
--- a/example_project/mappers/Baseline.rb
+++ b/example_project/mappers/Baseline.rb
@@ -686,7 +686,8 @@ module URBANopt
             rescue StandardError
             end
 
-            args[:weather_station_epw_filepath] = "../../../weather/#{feature.weather_filename}"
+            epw = File.expand_path(File.join(File.dirname(__FILE__), '../weather', feature.weather_filename))
+            args[:weather_station_epw_filepath] = epw
 
             # Geometry
             args[:geometry_building_num_units] = 1


### PR DESCRIPTION
The `run` directory, i.e., the location of the hpxml file, is not required to be exactly one level down from the `example_project` folder.