### PR TITLE
Integrate three measures from the openstudio-geb gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,14 @@ allow_local = ENV['FAVOR_LOCAL_GEMS']
 #   gem 'openstudio-extension', github: 'NREL/openstudio-extension-gem', branch: 'develop'
 # end
 
+if allow_local && File.exist?('../openstudio-geb-gem')
+  gem 'openstudio-geb', path: '../openstudio-geb-gem'
+elsif allow_local
+  gem 'openstudio-geb', github: 'LBNL-ETA/Openstudio-GEB-gem', branch: 'master'
+else
+  gem 'openstudio-geb', '~> 0.0.3'
+end
+
 if allow_local && File.exist?('../openstudio-common-measures-gem')
  gem 'openstudio-common-measures', path: '../openstudio-common-measures-gem'
 elsif allow_local

--- a/Rakefile
+++ b/Rakefile
@@ -150,6 +150,42 @@ def reopt_scenario(json, csv)
   return scenario
 end
 
+def chilled_water_storage_scenario(json, csv)
+  name = 'Chilled Water Storage Scenario'
+  run_dir = File.join(root_dir, 'run/chilled_water_storage_scenario/')
+  feature_file_path = File.join(root_dir, json)
+  csv_file = File.join(root_dir, csv)
+  mapper_files_dir = File.join(root_dir, 'mappers/')
+  num_header_rows = 1
+  feature_file = URBANopt::GeoJSON::GeoFile.from_file(feature_file_path)
+  scenario = URBANopt::Scenario::ScenarioCSV.new(name, root_dir, run_dir, feature_file, mapper_files_dir, csv_file, num_header_rows)
+  return scenario
+end
+
+def peak_hours_mels_shedding_scenario(json, csv)
+  name = 'Peak Hours MELs Shedding Scenario'
+  run_dir = File.join(root_dir, 'run/peak_hours_mels_shedding_scenario/')
+  feature_file_path = File.join(root_dir, json)
+  csv_file = File.join(root_dir, csv)
+  mapper_files_dir = File.join(root_dir, 'mappers/')
+  num_header_rows = 1
+  feature_file = URBANopt::GeoJSON::GeoFile.from_file(feature_file_path)
+  scenario = URBANopt::Scenario::ScenarioCSV.new(name, root_dir, run_dir, feature_file, mapper_files_dir, csv_file, num_header_rows)
+  return scenario
+end
+
+def peak_hours_thermostat_adjust_scenario(json, csv)
+  name = 'Peak Hours Thermostat Adjust Scenario'
+  run_dir = File.join(root_dir, 'run/peak_hours_thermostat_adjust_scenario/')
+  feature_file_path = File.join(root_dir, json)
+  csv_file = File.join(root_dir, csv)
+  mapper_files_dir = File.join(root_dir, 'mappers/')
+  num_header_rows = 1
+  feature_file = URBANopt::GeoJSON::GeoFile.from_file(feature_file_path)
+  scenario = URBANopt::Scenario::ScenarioCSV.new(name, root_dir, run_dir, feature_file, mapper_files_dir, csv_file, num_header_rows)
+  return scenario
+end
+
 def configure_project
   # write a runner.conf in project dir if it does not exist
   # delete runner.conf to automatically regenerate it

--- a/example_project/mappers/ChilledWaterStorage.rb
+++ b/example_project/mappers/ChilledWaterStorage.rb
@@ -1,0 +1,98 @@
+# *********************************************************************************
+# URBANopt™, Copyright (c) 2019-2022, Alliance for Sustainable Energy, LLC, and other
+# contributors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may be
+# used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+# *********************************************************************************
+# Mapper created by LBNL using the measure from openstudio-geb gem
+# (https://github.com/LBNL-ETA/Openstudio-GEB-gem)
+# *********************************************************************************
+
+require 'urbanopt/reporting'
+require 'openstudio/geb'
+
+require_relative 'Baseline'
+
+require 'json'
+
+module URBANopt
+  module Scenario
+    class ChilledWaterStorageMapper < BaselineMapper
+      def create_osw(scenario, features, feature_names)
+        osw = super(scenario, features, feature_names)
+
+        feature = features[0]
+        building_type = feature.building_type
+
+        # Only apply to commercial buildings, not residential models
+        if commercial_building_types.include? building_type
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', '__SKIP__', false)
+          # Provide a tank volume in m3 or a sizing run will be run to decide the tank volume automatically
+          # OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'tank_vol', 2)
+
+          # Select to use the tank for "Full Storage" or "Partial Storage"
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'objective', 'Partial Storage')
+
+          # Select a plant loop as the primary loop to add the water tank on. By default it will be "Chilled water loop" if exists
+          # OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'selected_primary_loop_name', "Chilled water loop")
+
+          # Primary Loop (charging) Setpoint Temperature in degree C
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'primary_loop_sp', 6.7)
+          # Secondary Loop (discharging) Setpoint Temperature in degree C
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'secondary_loop_sp', 6.7)
+          # Chilled Water Tank Setpoint Temperature in degree C
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'tank_charge_sp', 6.7)
+          # Loop Design Temperature Difference in degree C. Use the existing setting or provide a numeric value
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'primary_delta_t', 'Use Existing Loop Value')
+          # Secondary Loop Design Temperature Difference in degree C
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'secondary_delta_t', 4.5)
+
+          # Seasonal Availability of Chilled Water Storage. Use MM/DD-MM/DD format, e.g., 04/01-10/31, default is full year.
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'thermal_storage_season', '01/01-12/31')
+          # Starting Time for Chilled Water Tank Discharge. Use 24 hour format (HH:MM)
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'discharge_start', '08:00')
+          # End Time for Chilled Water Tank Discharge. Use 24 hour format (HH:MM)
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'discharge_end', '21:00')
+          # Starting Time for Chilled Water Tank Charge. Use 24 hour format (HH:MM)
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'charge_start', '23:00')
+          # End Time for Chilled Water Tank Charge. Use 24 hour format (HH:MM)
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'charge_end', '07:00')
+
+          # Allow Chilled Water Tank Work on Weekends?
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'wknds', false)
+
+          # Provide an output path for tank sizing run (if tank volume is not provided)
+          OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'run_output_path', '.')
+
+          # Provide a epw file path for tank sizing run (if tank volume is not provided). By default it uses the model's weather file
+          # OpenStudio::Extension.set_measure_argument(osw, 'add_chilled_water_storage_tank', 'epw_path', feature.weather_filename)
+        end
+
+        return osw
+      end
+    end
+  end
+end

--- a/example_project/mappers/PeakHoursMelsShedding.rb
+++ b/example_project/mappers/PeakHoursMelsShedding.rb
@@ -1,0 +1,73 @@
+# *********************************************************************************
+# URBANopt™, Copyright (c) 2019-2022, Alliance for Sustainable Energy, LLC, and other
+# contributors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may be
+# used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+# *********************************************************************************
+# Mapper created by LBNL using the measure from openstudio-geb gem
+# (https://github.com/LBNL-ETA/Openstudio-GEB-gem)
+# *********************************************************************************
+
+require 'urbanopt/reporting'
+require 'openstudio/geb'
+
+require_relative 'Baseline'
+
+require 'json'
+
+module URBANopt
+  module Scenario
+    class PeakHoursMelsSheddingMapper < BaselineMapper
+      # The measure reduces electric equipment loads by a user-specified percentage for a user-specified time period (usually the peak hours).
+      # The reduction can be applied to at most three periods throughout out the year specified by the user.
+      # This is applied throughout the entire building.
+      def create_osw(scenario, features, feature_names)
+        osw = super(scenario, features, feature_names)
+        OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', '__SKIP__', false)
+        # Percentage Reduction of Electric Equipment Power (%). Enter a value between 0 and 100
+        OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'epd_reduce_percent', 50.0)
+        # Starting Time for the Reduction in HH:MM:SS format
+        OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'start_time', '17:00:00')
+        # End Time for the Reduction in HH:MM:SS format
+        OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'end_time', '21:00:00')
+
+        # First Starting Date for the Reduction in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'start_date1', '07-01')
+        # First End Date for the Reduction in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'end_date1', '08-31')
+        # Second Starting Date for the Reduction in MM-DD format. Leave it blank if not needed
+        # OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'start_date2', '')
+        # Second End Date for the Reduction in MM-DD format. Leave it blank if not needed
+        # OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'end_date2', '')
+        # Third Starting Date for the Reduction in MM-DD format. Leave it blank if not needed
+        # OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'start_date3', '')
+        # Third End Date for the Reduction in MM-DD format. Leave it blank if not needed
+        # OpenStudio::Extension.set_measure_argument(osw, 'reduce_epd_by_percentage_for_peak_hours', 'end_date3', '')
+        return osw
+      end
+    end
+  end
+end

--- a/example_project/mappers/PeakHoursThermostatAdjust.rb
+++ b/example_project/mappers/PeakHoursThermostatAdjust.rb
@@ -1,0 +1,79 @@
+# *********************************************************************************
+# URBANopt™, Copyright (c) 2019-2022, Alliance for Sustainable Energy, LLC, and other
+# contributors. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list
+# of conditions and the following disclaimer.
+#
+# Redistributions in binary form must reproduce the above copyright notice, this
+# list of conditions and the following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# Neither the name of the copyright holder nor the names of its contributors may be
+# used to endorse or promote products derived from this software without specific
+# prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+# *********************************************************************************
+# Mapper created by LBNL using the measure from openstudio-geb gem
+# (https://github.com/LBNL-ETA/Openstudio-GEB-gem)
+# *********************************************************************************
+
+require 'urbanopt/reporting'
+require 'openstudio/geb'
+
+require_relative 'Baseline'
+
+require 'json'
+
+module URBANopt
+  module Scenario
+    class PeakHoursThermostatAdjustMapper < BaselineMapper
+      # The measure adjusts heating and cooling setpoints by a user-specified number of degrees and a user-specified time period.
+      # This is applied throughout the entire building.
+      def create_osw(scenario, features, feature_names)
+        osw = super(scenario, features, feature_names)
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', '__SKIP__', false)
+        # Degrees Fahrenheit to Adjust Cooling Setpoint By
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'cooling_adjustment', 2.0)
+        # Daily Start Time for Cooling Adjustment. Use 24 hour format HH:MM:SS
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'cooling_daily_starttime', '16:01:00')
+        # Daily End Time for Cooling Adjustment. Use 24 hour format HH:MM:SS
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'cooling_daily_endtime', '20:00:00')
+        # Start Date for Cooling Adjustment in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'cooling_startdate', '06-01')
+        # End Date for Cooling Adjustment in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'cooling_enddate', '09-30')
+
+        # Degrees Fahrenheit to Adjust Heating Setpoint By
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'heating_adjustment', -2.0)
+        # Daily Start Time for Heating Adjustment. Use 24 hour format HH:MM:SS
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'heating_daily_starttime', '18:01:00')
+        # Daily End Time for Heating Adjustment. Use 24 hour format HH:MM:SS
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'heating_daily_endtime', '22:00:00')
+        # Start Date for Heating Adjustment Period 1 in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'heating_startdate_1', '01-01')
+        # End Date for Heating Adjustment Period 1 in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'heating_enddate_1', '05-31')
+        # Start Date for Heating Adjustment Period 2 in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'heating_startdate_2', '10-01')
+        # End Date for Heating Adjustment Period 2 in MM-DD format
+        OpenStudio::Extension.set_measure_argument(osw, 'AdjustThermostatSetpointsByDegreesForPeakHours', 'heating_enddate_2', '12-31')
+
+        return osw
+      end
+    end
+  end
+end

--- a/example_project/mappers/base_workflow.osw
+++ b/example_project/mappers/base_workflow.osw
@@ -169,6 +169,50 @@
         "charge_start": "23:00"
       }
     },{
+      "measure_dir_name": "reduce_epd_by_percentage_for_peak_hours",
+      "arguments": {
+        "__SKIP__": true,
+        "epd_reduce_percent": 50,
+        "start_time": "17:00:00",
+        "end_time": "21:00:00",
+        "start_date1": "07-01",
+        "end_date1": "08-31"
+      }
+    },
+    {
+      "measure_dir_name": "add_chilled_water_storage_tank",
+      "arguments": {
+        "__SKIP__": true,
+        "objective": "Partial Storage",
+        "primary_loop_sp": 6.7,
+        "secondary_loop_sp": 6.7,
+        "primary_delta_t": "Use Existing Loop Value",
+        "discharge_start": "08:00",
+        "discharge_end": "21:00",
+        "charge_start": "23:00",
+        "charge_end": "07:00",
+        "run_output_path": "."
+      }
+    },
+    {
+      "measure_dir_name": "AdjustThermostatSetpointsByDegreesForPeakHours",
+      "arguments": {
+        "__SKIP__": true,
+        "cooling_adjustment": 2,
+        "cooling_daily_starttime": "16:01:00",
+        "cooling_daily_endtime": "20:00:00",
+        "cooling_startdate": "06-01",
+        "cooling_enddate": "09-30",
+        "heating_adjustment": 2,
+        "heating_daily_starttime": "16:01:00",
+        "heating_daily_endtime": "20:00:00",
+        "heating_startdate_1": "01-01",
+        "heating_enddate_1": "05-31",
+        "heating_startdate_2": "10-01",
+        "heating_enddate_2": "12-31"
+      }
+    },
+    {
       "measure_dir_name":"export_time_series_modelica",
       "arguments":{
         "__SKIP__":false


### PR DESCRIPTION
Integrate three measures from the [openstudio-geb gem](https://github.com/LBNL-ETA/Openstudio-GEB-gem) as the urbanopt core contribution task of LBNL. 

- A new mapper has been created for each measure, inherited from the Baseline mapper

  | Measure Name  | Mapper Name |
  | ------------- | ------------- |
  | reduce_epd_by_percentage_for_peak_hours  | PeakHoursMelsShedding  |
  | add_chilled_water_storage_tank | ChilledWaterStorage  |
  | AdjustThermostatSetpointsByDegreesForPeakHours | PeakHoursThermostatAdjust |

- The three measures have been added to `base_workflow.osw`
- The openstudio-geb gem dependency has been added to `Gemfile`; Using [published geb gem v0.0.3](https://rubygems.org/gems/openstudio-geb/versions/0.0.3)
- Rake tasks for each scenario/mapper have been added to `Rakefile`
